### PR TITLE
Add `default-host` argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "openssl",
  "reqwest",
  "strum",
+ "strum_macros",
  "tar",
  "tempfile",
  "xz2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4.17"
 env_logger = "0.9.0"
 embuild = { version = "0.30.4", features = ["espidf", "git"] }
 strum = { version = "0.24", features = ["derive"] }
+strum_macros = "0.24.3"
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/host_triple.rs
+++ b/src/host_triple.rs
@@ -1,10 +1,11 @@
 use crate::emoji;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use guess_host_triple::guess_host_triple;
 use std::str::FromStr;
 use strum::Display;
+use strum_macros::EnumString;
 
-#[derive(Display, Debug, Clone)]
+#[derive(Display, Debug, Clone, EnumString)]
 pub enum HostTriple {
     /// 64-bit Linux
     #[strum(serialize = "x86_64-unknown-linux-gnu")]
@@ -26,30 +27,17 @@ pub enum HostTriple {
     Aarch64AppleDarwin,
 }
 
-impl FromStr for HostTriple {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "x86_64-unknown-linux-gnu" => Ok(HostTriple::X86_64UnknownLinuxGnu),
-            "aarch64-unknown-linux-gnu" => Ok(HostTriple::Aarch64UnknownLinuxGnu),
-            "x86_64-pc-windows-msvc" => Ok(HostTriple::X86_64PcWindowsMsvc),
-            "x86_64-pc-windows-gnu" => Ok(HostTriple::X86_64PcWindowsGnu),
-            "x86_64-apple-darwin" => Ok(HostTriple::X86_64AppleDarwin),
-            "aarch64-apple-darwin" => Ok(HostTriple::Aarch64AppleDarwin),
-            _ => Err(format!(
-                "{} Host triple '{}' is not supported.",
-                emoji::ERROR,
-                s
-            )),
-        }
-    }
-}
-
 /// Parse the host triple if specified, otherwise guess it.
 pub fn get_host_triple(host_triple_arg: Option<String>) -> Result<HostTriple> {
     let host_triple = match host_triple_arg {
-        Some(host_triple) => HostTriple::from_str(&host_triple).unwrap(),
+        Some(host_triple_string) => match FromStr::from_str(&host_triple_string) {
+            Ok(host_triple) => host_triple,
+            Err(_) => bail!(
+                "{} Host triple '{}' is not supported.",
+                emoji::ERROR,
+                host_triple_string
+            ),
+        },
         None => HostTriple::from_str(guess_host_triple().unwrap()).unwrap(),
     };
     Ok(host_triple)

--- a/src/host_triple.rs
+++ b/src/host_triple.rs
@@ -1,0 +1,56 @@
+use crate::emoji;
+use anyhow::Result;
+use guess_host_triple::guess_host_triple;
+use std::str::FromStr;
+use strum::Display;
+
+#[derive(Display, Debug, Clone)]
+pub enum HostTriple {
+    /// 64-bit Linux
+    #[strum(serialize = "x86_64-unknown-linux-gnu")]
+    X86_64UnknownLinuxGnu = 0,
+    /// ARM64 Linux
+    #[strum(serialize = "aarch64-unknown-linux-gnu")]
+    Aarch64UnknownLinuxGnu,
+    /// 64-bit MSVC
+    #[strum(serialize = "x86_64-pc-windows-msvc")]
+    X86_64PcWindowsMsvc,
+    /// 64-bit MinGW
+    #[strum(serialize = "x86_64-pc-windows-gnu")]
+    X86_64PcWindowsGnu,
+    /// 64-bit macOS
+    #[strum(serialize = "x86_64-apple-darwin")]
+    X86_64AppleDarwin,
+    /// ARM64 macOS
+    #[strum(serialize = "aarch64-apple-darwin")]
+    Aarch64AppleDarwin,
+}
+
+impl FromStr for HostTriple {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "x86_64-unknown-linux-gnu" => Ok(HostTriple::X86_64UnknownLinuxGnu),
+            "aarch64-unknown-linux-gnu" => Ok(HostTriple::Aarch64UnknownLinuxGnu),
+            "x86_64-pc-windows-msvc" => Ok(HostTriple::X86_64PcWindowsMsvc),
+            "x86_64-pc-windows-gnu" => Ok(HostTriple::X86_64PcWindowsGnu),
+            "x86_64-apple-darwin" => Ok(HostTriple::X86_64AppleDarwin),
+            "aarch64-apple-darwin" => Ok(HostTriple::Aarch64AppleDarwin),
+            _ => Err(format!(
+                "{} Host triple '{}' is not supported.",
+                emoji::ERROR,
+                s
+            )),
+        }
+    }
+}
+
+/// Parse the host triple if specified, otherwise guess it.
+pub fn get_host_triple(host_triple_arg: Option<String>) -> Result<HostTriple> {
+    let host_triple = match host_triple_arg {
+        Some(host_triple) => HostTriple::from_str(&host_triple).unwrap(),
+        None => HostTriple::from_str(guess_host_triple().unwrap()).unwrap(),
+    };
+    Ok(host_triple)
+}

--- a/src/host_triple.rs
+++ b/src/host_triple.rs
@@ -1,5 +1,5 @@
 use crate::emoji;
-use anyhow::{bail, Result};
+use anyhow::{Context, Result};
 use guess_host_triple::guess_host_triple;
 use std::str::FromStr;
 use strum::Display;
@@ -29,16 +29,14 @@ pub enum HostTriple {
 
 /// Parse the host triple if specified, otherwise guess it.
 pub fn get_host_triple(host_triple_arg: Option<String>) -> Result<HostTriple> {
-    let host_triple = match host_triple_arg {
-        Some(host_triple_string) => match FromStr::from_str(&host_triple_string) {
-            Ok(host_triple) => host_triple,
-            Err(_) => bail!(
-                "{} Host triple '{}' is not supported.",
-                emoji::ERROR,
-                host_triple_string
-            ),
-        },
-        None => HostTriple::from_str(guess_host_triple().unwrap()).unwrap(),
-    };
-    Ok(host_triple)
+    if let Some(host_triple_arg) = host_triple_arg {
+        HostTriple::from_str(&host_triple_arg).context(format!(
+            "{} Host triple '{}' is not supported.",
+            emoji::ERROR,
+            host_triple_arg,
+        ))
+    } else {
+        HostTriple::from_str(guess_host_triple().unwrap())
+            .context(format!("{} Unable to guess host triple.", emoji::ERROR,))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod emoji;
+pub mod host_triple;
 pub mod targets;
 pub mod toolchain;
 pub mod logging {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use espup::{
         },
     },
 };
+use guess_host_triple::guess_host_triple;
 use log::{debug, info};
 use std::{
     collections::HashSet,
@@ -56,6 +57,9 @@ pub enum SubCommand {
 
 #[derive(Debug, Parser)]
 pub struct InstallOpts {
+    /// Target triple of the host.
+    #[arg(short = 'd', long, required = false)]
+    pub defautl_host: Option<String>,
     /// ESP-IDF version to install. If empty, no esp-idf is installed. Version format:
     ///
     /// - `commit:<hash>`: Uses the commit `<hash>` of the `esp-idf` repository.
@@ -95,6 +99,9 @@ pub struct InstallOpts {
 
 #[derive(Debug, Parser)]
 pub struct UpdateOpts {
+    /// Target triple of the host.
+    #[arg(short = 'd', long, required = false)]
+    pub defautl_host: Option<String>,
     /// Verbosity level of the logs.
     #[arg(short = 'l', long, default_value = "info", value_parser = ["debug", "info", "warn", "error"])]
     pub log_level: String,
@@ -132,20 +139,25 @@ fn install(args: InstallOpts) -> Result<()> {
 
     info!("{} Installing esp-rs", emoji::DISC);
     let targets: HashSet<Target> = parse_targets(&args.targets).unwrap();
+    // TODO: Check the provided host triple.
+    let host_triple = args
+        .defautl_host
+        .unwrap_or_else(|| guess_host_triple().unwrap().to_string());
     let mut extra_crates: HashSet<RustCrate> =
         args.extra_crates.split(',').map(RustCrate::new).collect();
     let mut exports: Vec<String> = Vec::new();
     let export_file = args.export_file.clone();
-    let rust_toolchain = RustToolchain::new(args.toolchain_version.clone());
+    let rust_toolchain = RustToolchain::new(&args.toolchain_version, &host_triple);
 
     // Complete LLVM is failing for Windows, aarch64 MacOs, and aarch64 Linux, so we are using always minified.
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    let llvm = LlvmToolchain::new(args.profile_minimal);
+    let llvm = LlvmToolchain::new(args.profile_minimal, &host_triple);
     #[cfg(any(not(target_arch = "x86_64"), not(target_os = "linux")))]
-    let llvm = LlvmToolchain::new(true);
+    let llvm = LlvmToolchain::new(true, &host_triple);
 
     debug!(
         "{} Arguments:
+            - Host triple: {}
             - Targets: {:?}
             - ESP-IDF version: {:?}
             - Export file: {:?}
@@ -156,6 +168,7 @@ fn install(args: InstallOpts) -> Result<()> {
             - Profile Minimal: {:?}
             - Toolchain version: {:?}",
         emoji::INFO,
+        host_triple,
         targets,
         &args.espidf_version,
         export_file,
@@ -185,7 +198,7 @@ fn install(args: InstallOpts) -> Result<()> {
         exports.extend(repo.install()?);
         extra_crates.insert(RustCrate::new("ldproxy"));
     } else {
-        exports.extend(install_gcc_targets(targets)?);
+        exports.extend(install_gcc_targets(targets, &host_triple)?);
     }
 
     debug!(
@@ -249,17 +262,24 @@ fn update(args: UpdateOpts) -> Result<()> {
     initialize_logger(&args.log_level);
     info!("{} Updating Xtensa Rust toolchain", emoji::DISC);
 
+    // TODO: Check the provided host triple.
+    let host_triple = args
+        .defautl_host
+        .unwrap_or_else(|| guess_host_triple().unwrap().to_string());
+
     debug!(
         "{} Arguments:
+            - Host triple: {}
             - Toolchain version: {}",
         emoji::INFO,
+        host_triple,
         &args.toolchain_version,
     );
 
     info!("{} Deleting previous Xtensa Rust toolchain", emoji::WRENCH);
     remove_dir_all(get_rustup_home().join("toolchains").join("esp"))?;
 
-    let rust_toolchain = RustToolchain::new(args.toolchain_version);
+    let rust_toolchain = RustToolchain::new(&args.toolchain_version, &host_triple);
     rust_toolchain.install_xtensa_rust()?;
 
     info!("{} Update suscesfully completed!", emoji::CHECK);

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ pub enum SubCommand {
 pub struct InstallOpts {
     /// Target triple of the host.
     #[arg(short = 'd', long, required = false)]
-    pub defautl_host: Option<String>,
+    pub default_host: Option<String>,
     /// ESP-IDF version to install. If empty, no esp-idf is installed. Version format:
     ///
     /// - `commit:<hash>`: Uses the commit `<hash>` of the `esp-idf` repository.
@@ -101,7 +101,7 @@ pub struct InstallOpts {
 pub struct UpdateOpts {
     /// Target triple of the host.
     #[arg(short = 'd', long, required = false)]
-    pub defautl_host: Option<String>,
+    pub default_host: Option<String>,
     /// Verbosity level of the logs.
     #[arg(short = 'l', long, default_value = "info", value_parser = ["debug", "info", "warn", "error"])]
     pub log_level: String,
@@ -139,7 +139,7 @@ fn install(args: InstallOpts) -> Result<()> {
 
     info!("{} Installing esp-rs", emoji::DISC);
     let targets: HashSet<Target> = parse_targets(&args.targets).unwrap();
-    let host_triple = get_host_triple(args.defautl_host).unwrap();
+    let host_triple = get_host_triple(args.default_host).unwrap();
     let mut extra_crates: HashSet<RustCrate> =
         args.extra_crates.split(',').map(RustCrate::new).collect();
     let mut exports: Vec<String> = Vec::new();
@@ -258,7 +258,7 @@ fn uninstall(args: UninstallOpts) -> Result<()> {
 fn update(args: UpdateOpts) -> Result<()> {
     initialize_logger(&args.log_level);
     info!("{} Updating Xtensa Rust toolchain", emoji::DISC);
-    let host_triple = get_host_triple(args.defautl_host).unwrap();
+    let host_triple = get_host_triple(args.default_host).unwrap();
 
     debug!(
         "{} Arguments:

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,11 +1,13 @@
 //! ESP32 chip variants support.
 
 use crate::emoji;
+use anyhow::Context;
 use log::debug;
 use std::{collections::HashSet, str::FromStr};
 use strum::Display;
+use strum_macros::EnumString;
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Display)]
+#[derive(Clone, Copy, EnumString, PartialEq, Hash, Eq, Debug, Display)]
 pub enum Target {
     /// Xtensa LX7 based dual core
     #[strum(serialize = "esp32")]
@@ -19,20 +21,6 @@ pub enum Target {
     /// RISC-V based single core
     #[strum(serialize = "esp32c3")]
     ESP32C3,
-}
-
-impl FromStr for Target {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "esp32" => Ok(Target::ESP32),
-            "esp32s2" => Ok(Target::ESP32S2),
-            "esp32s3" => Ok(Target::ESP32S3),
-            "esp32c3" => Ok(Target::ESP32C3),
-            _ => Err(format!("{} Target '{}' is not supported", emoji::ERROR, s)),
-        }
-    }
 }
 
 /// Returns a vector of Chips from a comma or space separated string.
@@ -53,7 +41,15 @@ pub fn parse_targets(targets_str: &str) -> Result<HashSet<Target>, String> {
     };
 
     for target in targets_str {
-        targets.insert(FromStr::from_str(target).unwrap());
+        targets.insert(
+            Target::from_str(target)
+                .context(format!(
+                    "{} Target '{}' is not supported",
+                    emoji::ERROR,
+                    target
+                ))
+                .unwrap(),
+        );
     }
     debug!("{} Parsed targets: {:?}", emoji::DEBUG, targets);
     Ok(targets)

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -6,7 +6,6 @@ use std::{collections::HashSet, str::FromStr};
 use strum::Display;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Display)]
-
 pub enum Target {
     /// Xtensa LX7 based dual core
     #[strum(serialize = "esp32")]
@@ -23,7 +22,7 @@ pub enum Target {
 }
 
 impl FromStr for Target {
-    type Err = ();
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -31,7 +30,7 @@ impl FromStr for Target {
             "esp32s2" => Ok(Target::ESP32S2),
             "esp32s3" => Ok(Target::ESP32S3),
             "esp32c3" => Ok(Target::ESP32C3),
-            _ => Err(()),
+            _ => Err(format!("{} Target '{}' is not supported", emoji::ERROR, s)),
         }
     }
 }

--- a/src/toolchain/llvm_toolchain.rs
+++ b/src/toolchain/llvm_toolchain.rs
@@ -16,14 +16,16 @@ const DEFAULT_LLVM_VERSION: &str = "esp-14.0.0-20220415";
 
 #[derive(Debug)]
 pub struct LlvmToolchain {
+    /// LLVM Toolchain file name.
+    pub file_name: String,
+    /// Host triple.
+    pub host_triple: String,
+    /// LLVM Toolchain path.
+    pub path: PathBuf,
     /// The repository containing LVVM sources.
     pub repository_url: String,
     /// Repository release version to use.
     pub version: String,
-    /// LLVM Toolchain file name.
-    pub file_name: String,
-    /// LLVM Toolchain path.
-    pub path: PathBuf,
 }
 
 impl LlvmToolchain {
@@ -74,7 +76,7 @@ impl LlvmToolchain {
                 self.repository_url.clone(),
                 &format!(
                     "idf_tool_xtensa_elf_clang.{}",
-                    Self::get_artifact_extension(guess_host_triple::guess_host_triple().unwrap())
+                    Self::get_artifact_extension(&self.host_triple)
                 ),
                 self.path.to_str().unwrap(),
                 true,
@@ -95,10 +97,9 @@ impl LlvmToolchain {
     }
 
     /// Create a new instance with default values and proper toolchain version.
-    pub fn new(minified: bool) -> Self {
-        let host_triple = guess_host_triple::guess_host_triple().unwrap();
-        let version = DEFAULT_LLVM_VERSION.to_string();
+    pub fn new(minified: bool, host_triple: &str) -> Self {
         let file_name: String;
+        let version = DEFAULT_LLVM_VERSION.to_string();
         let repository_url: String;
         if minified {
             file_name = format!(
@@ -130,10 +131,11 @@ impl LlvmToolchain {
         )
         .into();
         Self {
+            file_name,
+            host_triple: host_triple.to_string(),
+            path,
             repository_url,
             version,
-            file_name,
-            path,
         }
     }
 }

--- a/src/toolchain/rust_toolchain.rs
+++ b/src/toolchain/rust_toolchain.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     emoji,
+    host_triple::HostTriple,
     toolchain::{download_file, espidf::get_dist_path, get_home_dir},
 };
 use anyhow::{bail, Result};
@@ -105,7 +106,7 @@ impl RustToolchain {
     }
 
     /// Create a new instance.
-    pub fn new(toolchain_version: &str, host_triple: &str) -> Self {
+    pub fn new(toolchain_version: &str, host_triple: &HostTriple) -> Self {
         let artifact_extension = get_artifact_extension(host_triple);
         let version = toolchain_version.to_string();
         let dist = format!("rust-{}-{}", version, host_triple);
@@ -176,9 +177,9 @@ impl RustCrate {
 }
 
 /// Gets the artifact extension based on the host architecture.
-fn get_artifact_extension(host_triple: &str) -> &str {
+fn get_artifact_extension(host_triple: &HostTriple) -> &str {
     match host_triple {
-        "x86_64-pc-windows-msvc" | "x86_64-pc-windows-gnu" => "zip",
+        HostTriple::X86_64PcWindowsMsvc | HostTriple::X86_64PcWindowsGnu => "zip",
         _ => "tar.xz",
     }
 }

--- a/src/toolchain/rust_toolchain.rs
+++ b/src/toolchain/rust_toolchain.rs
@@ -15,20 +15,22 @@ const DEFAULT_XTENSA_RUST_REPOSITORY: &str =
 
 #[derive(Debug)]
 pub struct RustToolchain {
+    /// Path to the cargo home directory.
+    pub cargo_home: PathBuf,
     /// Xtensa Rust toolchain file.
     pub dist_file: String,
     /// Xtensa Rust toolchain URL.
     pub dist_url: String,
+    /// Host triple.
+    pub host_triple: String,
+    /// Path to the rustup home directory.
+    pub rustup_home: PathBuf,
     #[cfg(unix)]
     /// Xtensa Src Rust toolchain file.
     pub src_dist_file: String,
     #[cfg(unix)]
     /// Xtensa Src Rust toolchain URL.
     pub src_dist_url: String,
-    /// Path to the cargo home directory.
-    pub cargo_home: PathBuf,
-    /// Path to the rustup home directory.
-    pub rustup_home: PathBuf,
     /// Xtensa Rust toolchain destination path.
     pub toolchain_destination: PathBuf,
     /// Xtensa Rust Toolchain version.
@@ -57,7 +59,6 @@ impl RustToolchain {
 
         #[cfg(unix)]
         if cfg!(unix) {
-            let host_triple = guess_host_triple::guess_host_triple().unwrap();
             download_file(
                 self.dist_url.clone(),
                 "rust.tar.xz",
@@ -69,7 +70,7 @@ impl RustToolchain {
             let arguments = format!(
                 "{}/rust-nightly-{}/install.sh --destdir={} --prefix='' --without=rust-docs",
                 get_dist_path("rust"),
-                host_triple,
+                &self.host_triple,
                 self.toolchain_destination.display()
             );
             cmd!("/bin/bash", "-c", arguments).run()?;
@@ -104,10 +105,9 @@ impl RustToolchain {
     }
 
     /// Create a new instance.
-    pub fn new(toolchain_version: String) -> Self {
-        let host_triple = guess_host_triple::guess_host_triple().unwrap();
+    pub fn new(toolchain_version: &str, host_triple: &str) -> Self {
         let artifact_extension = get_artifact_extension(host_triple);
-        let version = toolchain_version;
+        let version = toolchain_version.to_string();
         let dist = format!("rust-{}-{}", version, host_triple);
         let dist_file = format!("{}.{}", dist, artifact_extension);
         let dist_url = format!(
@@ -130,14 +130,15 @@ impl RustToolchain {
         #[cfg(windows)]
         let toolchain_destination = rustup_home.join("toolchains");
         Self {
+            cargo_home,
             dist_file,
             dist_url,
+            host_triple: host_triple.to_string(),
+            rustup_home,
             #[cfg(unix)]
             src_dist_file,
             #[cfg(unix)]
             src_dist_url,
-            cargo_home,
-            rustup_home,
             toolchain_destination,
             version,
         }


### PR DESCRIPTION
This argument is [also present on rustup](https://rust-lang.github.io/rustup/installation/other.html?highlight=default-host#other-installation-methods) and it would be necessary for #9 and #10.