### PR TITLE
Feature/doc update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.10"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1a0a4208c6c483b952ad35c6eed505fc13b46f08f631b81e828084a9318d74"
+checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
 dependencies = [
  "atty",
  "bitflags",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.10"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -750,9 +750,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "log"
@@ -899,9 +899,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.23.0+1.1.1r"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "479b452550ae92d653886cc875c673f2cf55a88d8044b7c0c58988af787a5ca2"
 dependencies = [
  "cc",
 ]
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",
@@ -1511,9 +1511,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ strum = { version = "0.24", features = ["derive"] }
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 
+[target.x86_64-unknown-linux-gnu.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
 bin-dir = "{ bin }{ binary-ext }"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ curl -L https://github.com/esp-rs/espup/releases/download/v0.1.0/espup-x86_64-ap
 chmod a+x espup
 ```
 
+### Windows
+```powershell
+Invoke-WebRequest 'https://github.com/esp-rs/espup/releases/download/v0.1.0/espup-x86_64-pc-windows-msvc.exe' -OutFile .\espup.exe
+```
 
 It's also possible to install from source code:
 ```sh

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ developing applications in Rust for Espressif SoC's.
 ### Linux
 - Ubuntu/Debian
 ```sh
-sudo apt-get install -y git curl gcc clang ninja-build cmake libudev-dev unzip xz-utils \
-python3 python3-pip python3-venv libusb-1.0-0 libssl-dev pkg-config libtinfo5 libpython2.7
+sudo apt-get install -y git curl gcc clang ninja-build cmake libudev-dev \
+python3 python3-pip python3-venv libusb-1.0-0 libssl-dev pkg-config
 ```
 - openSUSE Thumbleweed
 ```
@@ -38,11 +38,24 @@ sudo zypper install -y git gcc libudev-devel ninja python3 python38-pip
 
 Download the pre-compiled [release binaries](https://github.com/esp-rs/espup/releases) or using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
 
-### Linux
+### Linux x86_64
 ```sh
 curl -L https://github.com/esp-rs/espup/releases/download/v0.1.0/espup-x86_64-unknown-linux-gnu -o espup
 chmod a+x espup
 ```
+
+### macOS aarch64
+```sh
+curl -L https://github.com/esp-rs/espup/releases/download/v0.1.0/espup-aarch64-apple-darwin -o espup
+chmod a+x espup
+```
+
+### macOS x86_64
+```sh
+curl -L https://github.com/esp-rs/espup/releases/download/v0.1.0/espup-x86_64-apple-darwin -o espup
+chmod a+x espup
+```
+
 
 It's also possible to install from source code:
 ```sh

--- a/README.md
+++ b/README.md
@@ -26,16 +26,28 @@ developing applications in Rust for Espressif SoC's.
 ### Linux
 - Ubuntu/Debian
 ```sh
-apt-get install -y git curl gcc clang ninja-build cmake libudev-dev unzip xz-utils \
+sudo apt-get install -y git curl gcc clang ninja-build cmake libudev-dev unzip xz-utils \
 python3 python3-pip python3-venv libusb-1.0-0 libssl-dev pkg-config libtinfo5 libpython2.7
+```
+- openSUSE Thumbleweed
+```
+sudo zypper install -y git gcc libudev-devel ninja python3 python38-pip
 ```
 
 ## Installation
 
+Download the pre-compiled [release binaries](https://github.com/esp-rs/espup/releases) or using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
+
+### Linux
+```sh
+curl -L https://github.com/esp-rs/espup/releases/download/v0.1.0/espup-x86_64-unknown-linux-gnu -o espup
+chmod a+x espup
+```
+
+It's also possible to install from source code:
 ```sh
 cargo install espup --git https://github.com/esp-rs/espup
 ```
-It's also possible to directly download the pre-compiled [release binaries](https://github.com/esp-rs/espup/releases) or using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
 
 
 ## Quickstart


### PR DESCRIPTION
Update README to include instructions for OpenSUSE Thumbleweed.

Add vendored SSL also for x86_64 linux.
Closes #17 