### PR TITLE
Check if GCC or LLVM are installed, if so, reuse them.

### DIFF
--- a/src/toolchain/espidf.rs
+++ b/src/toolchain/espidf.rs
@@ -166,7 +166,7 @@ impl EspIdfRepo {
     pub fn new(version: &str, minified: bool, targets: HashSet<Target>) -> EspIdfRepo {
         let install_path = PathBuf::from(get_tools_path());
         debug!(
-            "{} ESP-IDF install path: {}",
+            "{} ESP-IDF install path: '{}'",
             emoji::DEBUG,
             install_path.display()
         );

--- a/src/toolchain/gcc_toolchain.rs
+++ b/src/toolchain/gcc_toolchain.rs
@@ -8,8 +8,11 @@ use crate::{
 };
 use anyhow::Result;
 use embuild::espidf::EspIdfVersion;
-use log::{debug, info};
-use std::collections::HashSet;
+use log::{debug, info, warn};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 const DEFAULT_GCC_REPOSITORY: &str = "https://github.com/espressif/crosstool-NG/releases/download";
 const DEFAULT_GCC_RELEASE: &str = "esp-2021r2-patch5";
@@ -42,10 +45,17 @@ impl GccToolchain {
     /// Installs the gcc toolchain.
     pub fn install(&self) -> Result<()> {
         let target_dir = format!("{}/{}-{}", self.toolchain_name, self.release, self.version);
-
         let gcc_path = get_tool_path(&target_dir);
         let extension = get_artifact_extension(&self.host_triple);
         debug!("{} GCC path: {}", emoji::DEBUG, gcc_path);
+        if Path::new(&PathBuf::from(&gcc_path)).exists() {
+            warn!(
+                "{} Previous installation of GCC exist in: '{}'. Reusing this installation.",
+                emoji::WARN,
+                &gcc_path
+            );
+            return Ok(());
+        }
         let gcc_file = format!(
             "{}-gcc{}-{}-{}.{}",
             self.toolchain_name,

--- a/src/toolchain/llvm_toolchain.rs
+++ b/src/toolchain/llvm_toolchain.rs
@@ -6,7 +6,7 @@ use crate::{
     toolchain::{download_file, espidf::get_tool_path},
 };
 use anyhow::{bail, Ok, Result};
-use log::info;
+use log::{info, warn};
 use std::path::{Path, PathBuf};
 
 const DEFAULT_LLVM_COMPLETE_REPOSITORY: &str =
@@ -66,11 +66,11 @@ impl LlvmToolchain {
         let mut exports: Vec<String> = Vec::new();
 
         if Path::new(&self.path).exists() {
-            bail!(
-            "{} Previous installation of LLVM exist in: {}.\n Please, remove the directory before new installation.",
-            emoji::WARN,
-            self.path.to_str().unwrap()
-        );
+            warn!(
+                "{} Previous installation of LLVM exist in: '{}'. Reusing this installation.",
+                emoji::WARN,
+                self.path.to_str().unwrap()
+            );
         } else {
             info!("{} Installing Xtensa elf Clang", emoji::WRENCH);
             download_file(

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -30,13 +30,17 @@ pub fn download_file(
 ) -> Result<String> {
     let file_path = format!("{}/{}", output_directory, file_name);
     if Path::new(&file_path).exists() {
-        info!("{} Using cached file: {}", emoji::INFO, file_path);
+        info!("{} Using cached file: '{}'", emoji::INFO, file_path);
         return Ok(file_path);
     } else if !Path::new(&output_directory).exists() {
-        info!("{} Creating directory: {}", emoji::WRENCH, output_directory);
+        info!(
+            "{} Creating directory: '{}'",
+            emoji::WRENCH,
+            output_directory
+        );
         if let Err(_e) = create_dir_all(output_directory) {
             bail!(
-                "{} Creating directory {} failed",
+                "{} Creating directory '{}' failed",
                 emoji::ERROR,
                 output_directory
             );
@@ -61,7 +65,7 @@ pub fn download_file(
             }
             "gz" => {
                 info!(
-                    "{} Uncompressing tar.gz file to {}",
+                    "{} Uncompressing tar.gz file to '{}'",
                     emoji::WRENCH,
                     output_directory
                 );
@@ -72,7 +76,7 @@ pub fn download_file(
             }
             "xz" => {
                 info!(
-                    "{} Uncompressing tar.xz file to {}",
+                    "{} Uncompressing tar.xz file to '{}'",
                     emoji::WRENCH,
                     output_directory
                 );
@@ -82,11 +86,15 @@ pub fn download_file(
                 archive.unpack(output_directory).unwrap();
             }
             _ => {
-                bail!("{} Unsuported file extension: {}", emoji::ERROR, extension);
+                bail!(
+                    "{} Unsuported file extension: '{}'",
+                    emoji::ERROR,
+                    extension
+                );
             }
         }
     } else {
-        info!("{} Creating file: {}", emoji::WRENCH, file_path);
+        info!("{} Creating file: '{}'", emoji::WRENCH, file_path);
         let mut out = File::create(file_path)?;
         copy(&mut resp, &mut out)?;
     }

--- a/src/toolchain/rust_toolchain.rs
+++ b/src/toolchain/rust_toolchain.rs
@@ -47,7 +47,7 @@ impl RustToolchain {
         let toolchain_path = self.toolchain_destination.clone().join("esp");
         if toolchain_path.exists() {
             bail!(
-                "{} Previous installation of Rust Toolchain exist in: {}.\n Please, remove the directory before new installation.",
+                "{} Previous installation of Rust Toolchain exist in: '{}'. Please, remove the directory before new installation.",
                 emoji::WARN,
                 self.toolchain_destination.display()
             );


### PR DESCRIPTION
- Reuse GCC if installed for the target
- Reuse LLVM if installed
- Improve how paths are printed