### PR TITLE
Add `rustup` as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Continuous Integration](https://github.com/esp-rs/espup/actions/workflows/ci.yaml/badge.svg)](https://github.com/esp-rs/espup/actions/workflows/ci.yaml)
 [![Security audit](https://github.com/esp-rs/espup/actions/workflows/audit.yaml/badge.svg)](https://github.com/esp-rs/espup/actions/workflows/audit.yaml)
 [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/esp-rs/espup)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&color=BEC5C9&labelColor=1C2C2E&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
 > `rustup` for [esp-rs](https://github.com/esp-rs/)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ developing applications in Rust for Espressif SoC's.
 >  This application is still under development and should be considered experimental
 
 ## Requirements
-Before running or installing `espup`, make sure that [rustup](https://www.rust-lang.org/tools/install)
+Before running or installing `espup`, make sure that [`rustup`](https://www.rust-lang.org/tools/install)
 and the following dependencies are installed.
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ developing applications in Rust for Espressif SoC's.
 >  This application is still under development and should be considered experimental
 
 ## Requirements
-
+Before running or installing `espup`, make sure that [rustup](https://www.rust-lang.org/tools/install)
+and the following dependencies are installed.
 ### Windows
 
 - Python must be installed and the version should be between `3.6` and `3.10`.

--- a/src/toolchain/rust_toolchain.rs
+++ b/src/toolchain/rust_toolchain.rs
@@ -1,9 +1,11 @@
 //! Xtensa Rust Toolchain source and installation tools
 
+#[cfg(unix)]
+use super::espidf::get_dist_path;
 use crate::{
     emoji,
     host_triple::HostTriple,
-    toolchain::{download_file, espidf::get_dist_path, get_home_dir},
+    toolchain::{download_file, get_home_dir},
 };
 use anyhow::{bail, Result};
 use embuild::cmd;

--- a/src/toolchain/rust_toolchain.rs
+++ b/src/toolchain/rust_toolchain.rs
@@ -194,97 +194,24 @@ pub fn get_rustup_home() -> PathBuf {
     PathBuf::from(env::var("RUSTUP_HOME").unwrap_or_else(|_e| get_home_dir() + "/.rustup"))
 }
 
-/// Checks if rustup and the proper nightly version are installed. If they are
-/// not, proceed to install them.
+/// Checks if rustup and the proper nightly version are installed. If rustup is not installed,
+/// it bails. If nigthly version is not installed, proceed to install it.
 pub fn check_rust_installation(nightly_version: &str) -> Result<()> {
     info!("{} Checking existing Rust installation", emoji::WRENCH);
 
-    match cmd!("rustup", "toolchain", "list")
+    if let Ok(child_output) = cmd!("rustup", "toolchain", "list")
         .into_inner()
         .stdout(Stdio::piped())
         .output()
     {
-        Ok(child_output) => {
-            let result = String::from_utf8_lossy(&child_output.stdout);
-            if !result.contains("nightly") {
-                warn!("{} Rust nightly toolchain not found", emoji::WARN);
-                install_rust_nightly(nightly_version)?;
-            }
+        let result = String::from_utf8_lossy(&child_output.stdout);
+        if !result.contains("nightly") {
+            warn!("{} Rust nightly toolchain not found", emoji::WARN);
+            install_rust_nightly(nightly_version)?;
         }
-        Err(e) => {
-            if let std::io::ErrorKind::NotFound = e.kind() {
-                warn!("{} rustup was not found.", emoji::WARN);
-                install_rustup(nightly_version)?;
-            } else {
-                bail!("{} Error: {}", emoji::ERROR, e);
-            }
-        }
+    } else {
+        bail!("{} rustup was not found. Please, install rustup: https://www.rust-lang.org/tools/install", emoji::ERROR);
     }
-    Ok(())
-}
-
-/// Installs rustup
-fn install_rustup(nightly_version: &str) -> Result<()> {
-    #[cfg(windows)]
-    let rustup_init_path = download_file(
-        "https://win.rustup.rs/x86_64".to_string(),
-        "rustup-init.exe",
-        &get_dist_path("rustup"),
-        false,
-    )?;
-    #[cfg(unix)]
-    let rustup_init_path = download_file(
-        "https://sh.rustup.rs".to_string(),
-        "rustup-init.sh",
-        &get_dist_path("rustup"),
-        false,
-    )?;
-    info!(
-        "{} Installing rustup with {} toolchain",
-        emoji::WRENCH,
-        nightly_version
-    );
-
-    #[cfg(windows)]
-    cmd!(
-        rustup_init_path,
-        "--default-toolchain",
-        nightly_version,
-        "--profile",
-        "minimal",
-        "-y"
-    )
-    .run()?;
-    #[cfg(not(windows))]
-    cmd!(
-        "/bin/bash",
-        rustup_init_path,
-        "--default-toolchain",
-        nightly_version,
-        "--profile",
-        "minimal",
-        "-y"
-    )
-    .run()?;
-
-    #[cfg(windows)]
-    let path = format!(
-        "{};{}",
-        std::env::var("PATH").unwrap(),
-        get_cargo_home().join("bin").display()
-    );
-    #[cfg(unix)]
-    let path = format!(
-        "{}:{}",
-        std::env::var("PATH").unwrap(),
-        get_cargo_home().join("bin").display()
-    );
-
-    std::env::set_var("PATH", path);
-    warn!(
-        "{} Please restart your terminal after the installation for the changes to take effect.",
-        emoji::WARN
-    );
 
     Ok(())
 }


### PR DESCRIPTION
- If `rustup` is not installed throw an error with a reference to the installation website.
- Document that `rustup` should be installed

This change was discussed in #10 and would solve both #10 and #9