### PR TITLE
Avoid using hardcoded Xtensa Rust version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "serde_json",
  "strum",
  "strum_macros",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ directories-next = "2.0.0"
 serde = { version = "1.0.146", features = ["derive"] }
 miette = "5.4.1"
 regex = "1.6.0"
+serde_json = "1.0.87"
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ impl Config {
         let dirs = ProjectDirs::from("rs", "esp", "espup").unwrap();
         let file = dirs.config_dir().join("espup.toml");
 
-        let config = if let Ok(data) = read(&file) {
+        let config = if let Ok(data) = read(file) {
             toml::from_slice(&data).into_diagnostic()?
         } else {
             return Err(ErrReport::msg("No config file found"));

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -67,7 +67,7 @@ impl XtensaRust {
         let json: serde_json::Value = serde_json::from_str(&res)?;
         let mut version = json["tag_name"].to_string();
 
-        version.retain(|c| c != 'v');
+        version.retain(|c| c != 'v' && c != '"');
         Self::parse_version(&version)?;
         debug!("{} Latest Xtensa Rust version: {}", emoji::DEBUG, version);
         Ok(version)
@@ -181,6 +181,7 @@ impl XtensaRust {
 
     /// Parses the version of the Xtensa toolchain.
     pub fn parse_version(arg: &str) -> Result<String> {
+        debug!("{} Parsing Xtensa Rust version: {}", emoji::DEBUG, arg);
         let re = Regex::new(RE_TOOLCHAIN_VERSION).unwrap();
         if !re.is_match(arg) {
             bail!(

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -308,3 +308,19 @@ fn install_rust_nightly(version: &str) -> Result<()> {
     .run()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::toolchain::rust::XtensaRust;
+
+    #[test]
+    fn test_xtensa_rust_parse_version() {
+        assert_eq!(XtensaRust::parse_version("1.45.0.0").unwrap(), "1.45.0.0");
+        assert_eq!(XtensaRust::parse_version("1.45.0.1").unwrap(), "1.45.0.1");
+        assert_eq!(XtensaRust::parse_version("1.1.1.1").unwrap(), "1.1.1.1");
+        assert_eq!(XtensaRust::parse_version("a.1.1.1").is_err(), true);
+        assert_eq!(XtensaRust::parse_version("1.1.1.1.1").is_err(), true);
+        assert_eq!(XtensaRust::parse_version("1..1.1").is_err(), true);
+        assert_eq!(XtensaRust::parse_version("1._.*.1").is_err(), true);
+    }
+}

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -318,9 +318,9 @@ mod tests {
         assert_eq!(XtensaRust::parse_version("1.45.0.0").unwrap(), "1.45.0.0");
         assert_eq!(XtensaRust::parse_version("1.45.0.1").unwrap(), "1.45.0.1");
         assert_eq!(XtensaRust::parse_version("1.1.1.1").unwrap(), "1.1.1.1");
-        assert_eq!(XtensaRust::parse_version("a.1.1.1").is_err(), true);
-        assert_eq!(XtensaRust::parse_version("1.1.1.1.1").is_err(), true);
-        assert_eq!(XtensaRust::parse_version("1..1.1").is_err(), true);
-        assert_eq!(XtensaRust::parse_version("1._.*.1").is_err(), true);
+        assert!(XtensaRust::parse_version("a.1.1.1").is_err());
+        assert!(XtensaRust::parse_version("1.1.1.1.1").is_err());
+        assert!(XtensaRust::parse_version("1..1.1").is_err());
+        assert!(XtensaRust::parse_version("1._.*.1").is_err());
     }
 }

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -56,7 +56,7 @@ impl XtensaRust {
 
         let client = reqwest::blocking::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
-            .user_agent("foo")
+            .user_agent("espup")
             .build()
             .unwrap();
         let res = client


### PR DESCRIPTION
- Get the latest Xtensa Rust toolchain version from the latest release of `rust-build` repo.
- If no version is provided to the `update` and `install` subcommand is provided, it will use the latest.
- Add unit test for `XtensaRust::parse_version`