### PR TITLE
Add perl to the fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ sudo apt-get install -y git python3 python3-pip gcc build-essential curl pkg-con
   - `libtinfo5` is required by LLVM 15.
 - Fedora
 ```sh
-sudo dnf -y install git python3 python3-pip gcc systemd-devel ncurses-compat-libs
+sudo dnf -y install git python3 python3-pip perl gcc systemd-devel ncurses-compat-libs
 ```
   - `systemd-devel` is only required when installing `cargo-espflash`.
   - `python3` and `python3-pip` are only required when installing ESP-IDF.
+  - `perl` is required to build openssl-sys
   - `ncurses-compat-libs` is required by LLVM 15.
 - openSUSE Thumbleweed/Leap
 ```


### PR DESCRIPTION
I added perl to dependencies on fedora, else the compilation of espup fails