### PR TITLE
Add ESP32-C2 to list of recognized targets, simplify some code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ pub struct InstallOpts {
     ///  Minifies the installation.
     #[arg(short = 'm', long)]
     pub profile_minimal: bool,
-    /// Comma or space separated list of targets [esp32,esp32s2,esp32s3,esp32c3,all].
+    /// Comma or space separated list of targets [esp32,esp32s2,esp32s3,esp32c2,esp32c3,all].
     #[arg(short = 't', long, default_value = "all")]
     pub targets: String,
     /// Xtensa Rust toolchain version.

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -5,53 +5,48 @@ use anyhow::Context;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, str::FromStr};
-use strum::Display;
-use strum_macros::EnumString;
+use strum::{Display, IntoEnumIterator};
+use strum_macros::{EnumIter, EnumString};
 
-#[derive(Clone, Copy, EnumString, PartialEq, Hash, Eq, Debug, Display, Deserialize, Serialize)]
+#[derive(
+    Clone, Copy, EnumIter, EnumString, PartialEq, Hash, Eq, Debug, Display, Deserialize, Serialize,
+)]
+#[strum(serialize_all = "lowercase")]
 pub enum Target {
-    /// Xtensa LX7 based dual core
-    #[strum(serialize = "esp32")]
+    /// Xtensa LX6 based dual core
     ESP32 = 0,
     /// Xtensa LX7 based single core
-    #[strum(serialize = "esp32s2")]
     ESP32S2,
-    /// Xtensa LX7 based single core
-    #[strum(serialize = "esp32s3")]
+    /// Xtensa LX7 based dual core
     ESP32S3,
     /// RISC-V based single core
-    #[strum(serialize = "esp32c3")]
     ESP32C3,
 }
 
 /// Returns a vector of Chips from a comma or space separated string.
 pub fn parse_targets(targets_str: &str) -> Result<HashSet<Target>, String> {
     debug!("{} Parsing targets: {}", emoji::DEBUG, targets_str);
-    let mut targets: HashSet<Target> = HashSet::new();
-    if targets_str.contains("all") {
-        targets.insert(Target::ESP32);
-        targets.insert(Target::ESP32S2);
-        targets.insert(Target::ESP32S3);
-        targets.insert(Target::ESP32C3);
-        return Ok(targets);
-    }
-    let targets_str: HashSet<&str> = if targets_str.contains(' ') || targets_str.contains(',') {
-        targets_str.split([',', ' ']).collect()
+
+    let targets_str = targets_str.to_lowercase();
+    let targets_str = targets_str.trim();
+
+    let targets: HashSet<Target> = if targets_str.contains("all") {
+        Target::iter().collect()
     } else {
-        vec![targets_str].into_iter().collect()
+        targets_str
+            .split([',', ' '])
+            .map(|target| {
+                Target::from_str(target)
+                    .context(format!(
+                        "{} Target '{}' is not supported",
+                        emoji::ERROR,
+                        target
+                    ))
+                    .unwrap()
+            })
+            .collect()
     };
 
-    for target in targets_str {
-        targets.insert(
-            Target::from_str(target)
-                .context(format!(
-                    "{} Target '{}' is not supported",
-                    emoji::ERROR,
-                    target
-                ))
-                .unwrap(),
-        );
-    }
     debug!("{} Parsed targets: {:?}", emoji::DEBUG, targets);
     Ok(targets)
 }
@@ -86,7 +81,8 @@ mod tests {
                 Target::ESP32,
                 Target::ESP32S2,
                 Target::ESP32S3,
-                Target::ESP32C3
+                Target::ESP32C2,
+                Target::ESP32C3,
             ]
             .into_iter()
             .collect())

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -20,6 +20,8 @@ pub enum Target {
     /// Xtensa LX7 based dual core
     ESP32S3,
     /// RISC-V based single core
+    ESP32C2,
+    /// RISC-V based single core
     ESP32C3,
 }
 

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -110,7 +110,7 @@ pub fn get_toolchain_name(target: &Target) -> String {
         Target::ESP32 => "xtensa-esp32-elf".to_string(),
         Target::ESP32S2 => "xtensa-esp32s2-elf".to_string(),
         Target::ESP32S3 => "xtensa-esp32s3-elf".to_string(),
-        Target::ESP32C3 => "riscv32-esp-elf".to_string(),
+        Target::ESP32C2 | Target::ESP32C3 => "riscv32-esp-elf".to_string(),
     }
 }
 


### PR DESCRIPTION
Nothing ground-breaking here, just some small tweaks. Also fixed some of the doc comments in the `Target` enum which weren't quite right.