### PR TITLE
Fix Windows exports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -466,6 +466,8 @@ fn export_environment(export_file: &PathBuf, exports: &[String]) -> Result<(), E
     info!("{} Creating export file", emoji::WRENCH);
     let mut file = File::create(export_file)?;
     for e in exports.iter() {
+        #[cfg(windows)]
+        let e = e.replace('/', r#"\"#);
         file.write_all(e.as_bytes())?;
         file.write_all(b"\n")?;
     }

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -90,7 +90,7 @@ impl Installable for Gcc {
         #[cfg(windows)]
         exports.push(format!("$Env:PATH += \";{}\"", &self.get_bin_path()));
         #[cfg(unix)]
-        exports.push(format!("export PATH={}:$PATH", &self.get_bin_path()));
+        exports.push(format!("export PATH=\"{}:$PATH\"", &self.get_bin_path()));
 
         Ok(exports)
     }


### PR DESCRIPTION
- Windows export file now only contains` \` instead of mixing `/` and `\`.
- GCC paths are now exported between `"` for Unix.