### PR TITLE
Fix install help documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Usage: espup update [OPTIONS]
 
 Options:
   -d, --default-host <DEFAULT_HOST>
-          Target triple of the host
+          Target triple of the host [possible values: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, x86_64-pc-windows-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
   -l, --log-level <LOG_LEVEL>
           Verbosity level of the logs [default: info] [possible values: debug, info, warn, error]
   -v, --toolchain-version <TOOLCHAIN_VERSION>

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Options:
           When using this option, `ldproxy` crate will also be installed.
 
   -f, --export-file <EXPORT_FILE>
-          Relative or full path of the generated export file. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
+          Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
 
   -c, --extra-crates <EXTRA_CRATES>
           Comma or space list of extra crates to install

--- a/README.md
+++ b/README.md
@@ -149,8 +149,12 @@ Options:
   -d, --default-host <DEFAULT_HOST>
           Target triple of the host
 
+          [possible values: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, x86_64-pc-windows-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
+
   -e, --esp-idf-version <ESP_IDF_VERSION>
-          ESP-IDF version to install. If empty, no esp-idf is installed. Version format:
+          ESP-IDF version to install. If empty, no ESP-IDF is installed. ESP-IDF installation can also be managed by esp-idf-sys(https://github.com/esp-rs/esp-idf-sys).
+
+          Version format:
 
           - `commit:<hash>`: Uses the commit `<hash>` of the `esp-idf` repository.
 
@@ -165,7 +169,7 @@ Options:
           When using this option, `ldproxy` crate will also be installed.
 
   -f, --export-file <EXPORT_FILE>
-          Destination of the generated export file
+          Relative or full path of the generated export file. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
 
   -c, --extra-crates <EXTRA_CRATES>
           Comma or space list of extra crates to install
@@ -188,7 +192,9 @@ Options:
           [default: nightly]
 
   -m, --profile-minimal
-          Minifies the installation
+          Minifies the installation.
+
+          This will install a reduced version of LLVM, delete the folder where all the assets are downloaded, and, if installing ESP-IDF, delete some unncessary folders like docs and examples.
 
   -t, --targets <TARGETS>
           Comma or space separated list of targets [esp32,esp32s2,esp32s3,esp32c2,esp32c3,all]

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,4 +84,10 @@ pub enum Error {
         emoji::ERROR
     )]
     FailedToRemoveFile(String),
+    #[diagnostic(code(espup::wrong_export_file))]
+    #[error(
+        "{} Wrong export file destination: '{0}'. Please, use an absolte or releative path (including the file and its extension).",
+        emoji::ERROR
+    )]
+    WrongExportFile(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ pub struct InstallOpts {
     /// When using this option, `ldproxy` crate will also be installed.
     #[arg(short = 'e', long, required = false)]
     pub esp_idf_version: Option<String>,
-    /// Relative or full path of the generated export file. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html).
+    /// Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html).
     #[arg(short = 'f', long)]
     pub export_file: Option<PathBuf>,
     /// Comma or space list of extra crates to install.

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,9 @@ pub struct InstallOpts {
     /// Target triple of the host.
     #[arg(short = 'd', long, required = false, value_parser = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "x86_64-pc-windows-gnu" , "x86_64-apple-darwin" , "aarch64-apple-darwin"])]
     pub default_host: Option<String>,
-    /// ESP-IDF version to install. If empty, no esp-idf is installed. Version format:
+    /// ESP-IDF version to install. If empty, no ESP-IDF is installed. ESP-IDF installation can also be managed by esp-idf-sys(https://github.com/esp-rs/esp-idf-sys).
+    ///
+    ///  Version format:
     ///
     /// - `commit:<hash>`: Uses the commit `<hash>` of the `esp-idf` repository.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,5 +516,7 @@ mod tests {
             get_export_file(Some(PathBuf::from("/home/user/export.sh"))),
             Ok(export_file)
         ));
+        // Path is a directory instead of a file
+        assert!(get_export_file(Some(home_dir)).is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use log::{debug, info, warn};
 use miette::Result;
 use std::{
     collections::HashSet,
-    fs::{remove_dir_all, remove_file, File},
+    fs::{metadata, remove_dir_all, remove_file, File},
     io::Write,
     path::PathBuf,
 };
@@ -428,6 +428,10 @@ fn clear_dist_folder() -> Result<(), Error> {
 /// Returns the absolute path to the export file, uses the DEFAULT_EXPORT_FILE if no arg is provided.
 fn get_export_file(export_file: Option<PathBuf>) -> Result<PathBuf, Error> {
     if let Some(export_file) = export_file {
+        let metadata = export_file.metadata()?;
+        if !metadata.is_file() {
+            return Err(Error::WrongExportFile(export_file.display().to_string()));
+        }
         if export_file.is_absolute() {
             Ok(export_file)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,8 +428,7 @@ fn clear_dist_folder() -> Result<(), Error> {
 /// Returns the absolute path to the export file, uses the DEFAULT_EXPORT_FILE if no arg is provided.
 fn get_export_file(export_file: Option<PathBuf>) -> Result<PathBuf, Error> {
     if let Some(export_file) = export_file {
-        let metadata = export_file.metadata()?;
-        if !metadata.is_file() {
+        if export_file.is_dir() {
             return Err(Error::WrongExportFile(export_file.display().to_string()));
         }
         if export_file.is_absolute() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use log::{debug, info, warn};
 use miette::Result;
 use std::{
     collections::HashSet,
-    fs::{metadata, remove_dir_all, remove_file, File},
+    fs::{remove_dir_all, remove_file, File},
     io::Write,
     path::PathBuf,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,10 @@ pub struct InstallOpts {
     /// Nightly Rust toolchain version.
     #[arg(short = 'n', long, default_value = "nightly")]
     pub nightly_version: String,
-    ///  Minifies the installation.
+    /// Minifies the installation.
+    ///
+    /// This will install a reduced version of LLVM, delete the folder where all the assets are downloaded,
+    /// and, if installing ESP-IDF, delete some unncessary folders like docs and examples.
     #[arg(short = 'm', long)]
     pub profile_minimal: bool,
     /// Comma or space separated list of targets [esp32,esp32s2,esp32s3,esp32c2,esp32c3,all].

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ pub struct InstallOpts {
     /// When using this option, `ldproxy` crate will also be installed.
     #[arg(short = 'e', long, required = false)]
     pub esp_idf_version: Option<String>,
-    /// Destination of the generated export file.
+    /// Relative or full path of the generated export file. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html).
     #[arg(short = 'f', long)]
     pub export_file: Option<PathBuf>,
     /// Comma or space list of extra crates to install.


### PR DESCRIPTION
- Improved `esp-idf-version` documentation
- Improved `profile-minimal` documentation
- Improved `export-file` documentation
- Update usage sections of Readme
- If you provide a wrong path for `export-file` argument, the following error will prompt:
```sh
esp@7f6b5a7b7dc9:~/espup$ cargo r -r -- install -f some_directory/
   Compiling espup v0.2.5-dev (/home/esp/espup)
    Finished release [optimized] target(s) in 54.01s
     Running `target/release/espup install -f some_directory/`
[2022-12-29T13:09:51Z INFO ] 💽  Installing esp-rs
Error: espup::wrong_export_file

  × ⛔  Wrong export file destination: 'some_directory/'. Please, use an absolte or releative path (including the file and its extension).
```
See #121 for more details