### PR TITLE
Small fixes and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
 dependencies = [
- "bstr 1.0.1",
+ "bstr 1.1.0",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
+checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
 dependencies = [
  "memchr",
  "once_cell",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -230,9 +230,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chunked_transfer"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "cipher"
@@ -282,16 +282,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -414,16 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,17 +426,6 @@ name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -546,8 +524,7 @@ dependencies = [
  "async-trait",
  "clap",
  "console",
- "directories-next",
- "dirs",
+ "directories",
  "embuild",
  "env_logger",
  "flate2",
@@ -560,7 +537,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
  "tar",
  "tempfile",
  "thiserror",
@@ -937,9 +913,9 @@ checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
@@ -964,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jobserver"
@@ -994,9 +970,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1127,11 +1103,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1146,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -1295,9 +1271,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "predicates"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "itertools",
@@ -1346,18 +1322,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1515,9 +1491,9 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
@@ -1541,15 +1517,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -1611,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
@@ -1796,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2047,9 +2023,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-linebreak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.62"
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.0.32", features = ["derive"] }
-dirs = "4.0.0"
 flate2 = "1.0.25"
 guess_host_triple = "0.1.3"
 reqwest = "0.11.12"
@@ -30,7 +29,7 @@ env_logger = "0.10.0"
 embuild = { version = "0.31.0", features = ["espidf", "git"] }
 strum = { version = "0.24", features = ["derive"] }
 toml = "0.5.9"
-directories-next = "2.0.0"
+directories = "4.0.1"
 serde = { version = "1.0.152", features = ["derive"] }
 miette = { version = "5.5.0", features = ["fancy"] }
 regex = "1.7.0"
@@ -40,15 +39,12 @@ update-informer = "0.6.0"
 tokio = { version = "1.21.2", features = ["full"] }
 async-trait = "0.1.60"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 [dev-dependencies]
 assert_fs = "1.0.10"
 assert_cmd = "2.0.6"
-
-[target.aarch64-unknown-linux-gnu.dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
-
-[target.x86_64-unknown-linux-gnu.dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ log = "0.4.17"
 env_logger = "0.10.0"
 embuild = { version = "0.31.0", features = ["espidf", "git"] }
 strum = { version = "0.24", features = ["derive"] }
-strum_macros = "0.24.3"
 toml = "0.5.9"
 directories-next = "2.0.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::{
     emoji, error::Error, host_triple::HostTriple, targets::Target, toolchain::rust::XtensaRust,
 };
-use directories_next::ProjectDirs;
+use directories::ProjectDirs;
 use log::info;
 use miette::Result;
 use serde::{Deserialize, Serialize};

--- a/src/host_triple.rs
+++ b/src/host_triple.rs
@@ -4,7 +4,7 @@ use miette::Result;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use strum::Display;
-use strum_macros::EnumString;
+use strum::EnumString;
 
 #[derive(Display, Debug, Clone, EnumString, Deserialize, Serialize, Default)]
 pub enum HostTriple {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use dirs::home_dir;
+use directories::BaseDirs;
 use espup::{
     config::Config,
     emoji,
@@ -438,8 +438,10 @@ fn get_export_file(export_file: Option<PathBuf>) -> Result<PathBuf, Error> {
             Ok(current_dir.join(export_file))
         }
     } else {
-        let home_dir = home_dir().unwrap();
-        Ok(home_dir.join(DEFAULT_EXPORT_FILE))
+        Ok(BaseDirs::new()
+            .unwrap()
+            .home_dir()
+            .join(DEFAULT_EXPORT_FILE))
     }
 }
 
@@ -493,14 +495,14 @@ pub fn check_arguments(
 #[cfg(test)]
 mod tests {
     use crate::{export_environment, get_export_file, DEFAULT_EXPORT_FILE};
-    use dirs::home_dir;
+    use directories::BaseDirs;
     use std::{env::current_dir, path::PathBuf};
 
     #[test]
     #[allow(unused_variables)]
     fn test_get_export_file() {
         // No arg provided
-        let home_dir = home_dir().unwrap();
+        let home_dir = BaseDirs::new().unwrap().home_dir().to_path_buf();
         let export_file = home_dir.join(DEFAULT_EXPORT_FILE);
         assert!(matches!(get_export_file(None), Ok(export_file)));
         // Relative path

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,7 +272,7 @@ async fn install(args: InstallOpts) -> Result<()> {
 
     info!("{} Installation successfully completed!", emoji::CHECK);
     warn!(
-        "{} Please, source the export file, as state above, to properly setup the environment!",
+        "{} Please, source the export file, as stated above, to properly setup the environment!",
         emoji::WARN
     );
     Ok(())

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -6,7 +6,7 @@ use miette::Result;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, str::FromStr};
 use strum::{Display, IntoEnumIterator};
-use strum_macros::{EnumIter, EnumString};
+use strum::{EnumIter, EnumString};
 
 #[derive(
     Clone, Copy, EnumIter, EnumString, PartialEq, Hash, Eq, Debug, Display, Deserialize, Serialize,

--- a/src/toolchain/espidf.rs
+++ b/src/toolchain/espidf.rs
@@ -7,7 +7,7 @@ use crate::{
     toolchain::gcc::{get_toolchain_name, get_ulp_toolchain_name},
 };
 use async_trait::async_trait;
-use dirs::home_dir;
+use directories::BaseDirs;
 use embuild::{espidf, espidf::EspIdfRemote, git};
 use log::{debug, info};
 use miette::Result;
@@ -230,8 +230,16 @@ pub fn get_install_path(repo: EspIdfRemote) -> PathBuf {
 /// variable IDF_TOOLS_PATH is not set. Uses HOME/.espressif on Linux and macOS,
 /// and %USER_PROFILE%\.espressif on Windows.
 pub fn get_tools_path() -> String {
-    env::var("IDF_TOOLS_PATH")
-        .unwrap_or_else(|_e| home_dir().unwrap().display().to_string() + "/.espressif")
+    env::var("IDF_TOOLS_PATH").unwrap_or_else(|_e| {
+        format!(
+            "{}",
+            BaseDirs::new()
+                .unwrap()
+                .home_dir()
+                .join(".espressif")
+                .display()
+        )
+    })
 }
 
 /// Gets the espressif tools directory path. Tools directory is where the tools

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -96,7 +96,7 @@ impl Installable for Gcc {
         debug!("{} GCC path: {}", emoji::DEBUG, gcc_path);
         if Path::new(&PathBuf::from(&gcc_path)).exists() {
             warn!(
-                "{} Previous installation of GCC exist in: '{}'. Reusing this installation.",
+                "{} Previous installation of GCC exists in: '{}'. Reusing this installation.",
                 emoji::WARN,
                 &gcc_path
             );

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -98,7 +98,7 @@ impl Installable for Llvm {
 
         if Path::new(&self.path).exists() {
             warn!(
-                "{} Previous installation of LLVM exist in: '{}'. Reusing this installation.",
+                "{} Previous installation of LLVM exists in: '{}'. Reusing this installation.",
                 emoji::WARN,
                 self.path.to_str().unwrap()
             );

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -44,7 +44,7 @@ pub async fn download_file(
         }
     }
     info!(
-        "{} Downloading file {} from {}",
+        "{} Downloading file '{}' from '{}'",
         emoji::DOWNLOAD,
         file_name,
         url

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -177,7 +177,10 @@ impl Installable for XtensaRust {
                 &self.host_triple,
                 self.toolchain_destination.display()
             );
-            cmd!("/bin/bash", "-c", arguments).run()?;
+            cmd!("/bin/bash", "-c", arguments)
+                .into_inner()
+                .stdout(Stdio::null())
+                .spawn()?;
 
             download_file(
                 self.src_dist_url.clone(),
@@ -192,7 +195,10 @@ impl Installable for XtensaRust {
                 get_dist_path("rust-src"),
                 self.toolchain_destination.display()
             );
-            cmd!("/bin/bash", "-c", arguments).run()?;
+            cmd!("/bin/bash", "-c", arguments)
+                .into_inner()
+                .stdout(Stdio::null())
+                .spawn()?;
         }
         // Some platfroms like Windows are available in single bundle rust + src, because install
         // script in dist is not available for the plaform. It's sufficient to extract the toolchain
@@ -298,7 +304,9 @@ impl Installable for RiscVTarget {
             "--toolchain",
             &self.nightly_version
         )
-        .run()?;
+        .into_inner()
+        .stderr(Stdio::null())
+        .spawn()?;
         cmd!(
             "rustup",
             "target",
@@ -308,7 +316,9 @@ impl Installable for RiscVTarget {
             "riscv32imc-unknown-none-elf",
             "riscv32imac-unknown-none-elf"
         )
-        .run()?;
+        .into_inner()
+        .stderr(Stdio::null())
+        .spawn()?;
 
         Ok(vec![]) // No exports
     }

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -8,7 +8,7 @@ use crate::{
     toolchain::{download_file, espidf::get_dist_path},
 };
 use async_trait::async_trait;
-use dirs::home_dir;
+use directories::BaseDirs;
 use embuild::cmd;
 use log::{debug, info, warn};
 use miette::{IntoDiagnostic, Result};
@@ -324,18 +324,26 @@ fn get_artifact_extension(host_triple: &HostTriple) -> &str {
 
 /// Gets the default cargo home path.
 fn get_cargo_home() -> PathBuf {
-    PathBuf::from(
-        env::var("CARGO_HOME")
-            .unwrap_or_else(|_e| home_dir().unwrap().display().to_string() + "/.cargo"),
-    )
+    PathBuf::from(env::var("CARGO_HOME").unwrap_or_else(|_e| {
+        format!(
+            "{}",
+            BaseDirs::new().unwrap().home_dir().join(".cargo").display()
+        )
+    }))
 }
 
 /// Gets the default rustup home path.
 pub fn get_rustup_home() -> PathBuf {
-    PathBuf::from(
-        env::var("RUSTUP_HOME")
-            .unwrap_or_else(|_e| home_dir().unwrap().display().to_string() + "/.rustup"),
-    )
+    PathBuf::from(env::var("RUSTUP_HOME").unwrap_or_else(|_e| {
+        format!(
+            "{}",
+            BaseDirs::new()
+                .unwrap()
+                .home_dir()
+                .join(".rustup")
+                .display()
+        )
+    }))
 }
 
 /// Checks if rustup and the proper nightly version are installed. If rustup is not installed,
@@ -462,7 +470,7 @@ fn install_rust_nightly(version: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::toolchain::rust::{get_cargo_home, get_rustup_home, Crate, XtensaRust};
-    use dirs::home_dir;
+    use directories::BaseDirs;
     use std::collections::HashSet;
 
     #[test]
@@ -509,8 +517,10 @@ mod tests {
     fn test_get_cargo_home() {
         // No CARGO_HOME set
         std::env::remove_var("CARGO_HOME");
-        let home_dir = home_dir().unwrap();
-        assert_eq!(get_cargo_home(), home_dir.join(".cargo"));
+        assert_eq!(
+            get_cargo_home(),
+            BaseDirs::new().unwrap().home_dir().join(".cargo")
+        );
         // CARGO_HOME set
         let temp_dir = tempfile::TempDir::new().unwrap();
         let cargo_home = temp_dir.path().to_path_buf();
@@ -522,8 +532,10 @@ mod tests {
     fn test_get_rustup_home() {
         // No RUSTUP_HOME set
         std::env::remove_var("RUSTUP_HOME");
-        let home_dir = home_dir().unwrap();
-        assert_eq!(get_rustup_home(), home_dir.join(".rustup"));
+        assert_eq!(
+            get_rustup_home(),
+            BaseDirs::new().unwrap().home_dir().join(".rustup")
+        );
         // RUSTUP_HOME set
         let temp_dir = tempfile::TempDir::new().unwrap();
         let rustup_home = temp_dir.path().to_path_buf();


### PR DESCRIPTION
Nothing too interesting here:

- Don't depend directly on `strum_macros`, as it is already pulled in by `strum`'s **derive** feature
- Use the `directories` package instead of using both `dirs` and `directories-next`
    - Ironically, `directories` is now more up-to-date than `directories-next`
- Fix some small typos in the output, use more consistent quoting
- Silence the output from invoked script/application when installing Rust
    - This looked out of place in the output; there may be other places where this should be done as well
    - Might be a good idea to pull in the `indicatif` package and have status spinners for each step in the future?