### PR TITLE
Avoid spawning commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,8 +239,8 @@ async fn install(args: InstallOpts) -> Result<()> {
     }
 
     // With a list of applications to install, install them all in parallel.
-    let (tx, mut rx) = mpsc::channel::<Result<Vec<String>, Error>>(32);
     let installable_items = to_install.len();
+    let (tx, mut rx) = mpsc::channel::<Result<Vec<String>, Error>>(installable_items);
     for app in to_install {
         let tx = tx.clone();
         tokio::spawn(async move {

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -202,7 +202,7 @@ impl Installable for XtensaRust {
             cmd!("/bin/bash", "-c", arguments)
                 .into_inner()
                 .stdout(Stdio::null())
-                .spawn()?;
+                .output()?;
 
             download_file(
                 self.src_dist_url.clone(),
@@ -220,7 +220,7 @@ impl Installable for XtensaRust {
             cmd!("/bin/bash", "-c", arguments)
                 .into_inner()
                 .stdout(Stdio::null())
-                .spawn()?;
+                .output()?;
         }
         // Some platfroms like Windows are available in single bundle rust + src, because install
         // script in dist is not available for the plaform. It's sufficient to extract the toolchain
@@ -262,7 +262,7 @@ impl Crate {
         cmd!("cargo", "uninstall", extra_crate, "--quiet")
             .into_inner()
             .stdout(Stdio::null())
-            .spawn()?;
+            .output()?;
         Ok(())
     }
 }
@@ -283,7 +283,7 @@ impl Installable for Crate {
             cmd!("cargo", "install", &self.name, "--quiet")
                 .into_inner()
                 .stdout(Stdio::null())
-                .spawn()?;
+                .output()?;
         }
 
         Ok(vec![]) // No exports
@@ -317,7 +317,7 @@ impl RiscVTarget {
         )
         .into_inner()
         .stdout(Stdio::null())
-        .spawn()?;
+        .output()?;
         Ok(())
     }
 }
@@ -336,7 +336,7 @@ impl Installable for RiscVTarget {
         )
         .into_inner()
         .stderr(Stdio::null())
-        .spawn()?;
+        .output()?;
         cmd!(
             "rustup",
             "target",
@@ -348,7 +348,7 @@ impl Installable for RiscVTarget {
         )
         .into_inner()
         .stderr(Stdio::null())
-        .spawn()?;
+        .output()?;
 
         Ok(vec![]) // No exports
     }
@@ -457,7 +457,7 @@ async fn install_rustup(nightly_version: &str, host_triple: &HostTriple) -> Resu
     )
     .into_inner()
     .stdout(Stdio::null())
-    .spawn()?;
+    .output()?;
     #[cfg(not(windows))]
     cmd!(
         "/bin/bash",
@@ -473,7 +473,7 @@ async fn install_rustup(nightly_version: &str, host_triple: &HostTriple) -> Resu
     )
     .into_inner()
     .stdout(Stdio::null())
-    .spawn()?;
+    .output()?;
 
     #[cfg(windows)]
     let path = format!(
@@ -511,7 +511,7 @@ fn install_rust_nightly(version: &str) -> Result<(), Error> {
     )
     .into_inner()
     .stdout(Stdio::null())
-    .spawn()?;
+    .output()?;
     Ok(())
 }
 


### PR DESCRIPTION
- Avoid using hardcoded len for the `mscp`
- For some reason, when using `spawn`, some [CIs were failing ](https://github.com/SergioGasquez/esp-flasher-stub/actions/runs/3895145945/jobs/6650182204). I think what was happening was that the await was completed but the command was still running which lead to some parts of the toolchain not being properly installed.
  - This slows down the installation a bit
  - The same CI with this changes now works fine https://github.com/SergioGasquez/esp-flasher-stub/actions/runs/3902025238 
 
I was able to reproduce this issue in the CI and using doing the installation in a Dockerfile but not on host machines and neither on `esp-hal` CI.

I plan to create a new `espup` release once this is fixed, so we can update the rest of the CIs