### PR TITLE
Add installation retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-retry",
  "toml",
  "update-informer",
  "xz2",
@@ -1260,6 +1261,26 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2000,6 +2021,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ update-informer = "0.6.0"
 tokio = { version = "1.24.1", features = ["full"] }
 async-trait = "0.1.61"
 retry = "2.0.0"
+tokio-retry = "0.3.0"
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
     IoError(#[from] std::io::Error),
     #[error(transparent)]
     RewquestError(#[from] reqwest::Error),
-    #[diagnostic(code(espup::toolchain::failed_to_create_directory))]
+    #[diagnostic(code(espup::toolchain::failed_to_create_difrectory))]
     #[error("{} Creating directory '{0}' failed", emoji::ERROR)]
     FailedToCreateDirectory(String),
     #[diagnostic(code(espup::toolchain::unsupported_file_extension))]
@@ -44,9 +44,6 @@ pub enum Error {
     #[diagnostic(code(espup::toolchain::rust::failed_to_get_latest_version))]
     #[error("{} Failed To serialize Json from string.", emoji::ERROR)]
     FailedToSerializeJson,
-    #[diagnostic(code(espup::toolchain::rust::xtensa_rust_already_installed))]
-    #[error("{} Previous installation of Rust Toolchain exists in: '{0}'. Please, remove the directory before new installation.", emoji::ERROR)]
-    XtensaToolchainAlreadyInstalled(String),
     #[diagnostic(code(espup::toolchain::rust::invalid_version))]
     #[error(
         "{} Invalid toolchain version '{0}'. Verify that the format is correct: '<major>.<minor>.<patch>.<subpatch>' or '<major>.<minor>.<patch>', and that the release exists in https://github.com/esp-rs/rust-build/releases",
@@ -63,7 +60,7 @@ pub enum Error {
     #[error("{} Failed to add CMake to ESP-IDF tools", emoji::ERROR)]
     FailedToInstantiateCmake,
     #[diagnostic(code(espup::toolchain::espidf::failed_to_create_esp_idf_install_closure))]
-    #[error("{} Failed to create ESP-IDF  install closure", emoji::ERROR)]
+    #[error("{} Failed to create ESP-IDF install closure", emoji::ERROR)]
     FailedToCreateEspIdfInstallClosure,
     #[diagnostic(code(espup::toolchain::espidf::failed_to_install_esp_idf))]
     #[error("{} Failed to install ESP-IDF", emoji::ERROR)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
     IoError(#[from] std::io::Error),
     #[error(transparent)]
     RewquestError(#[from] reqwest::Error),
-    #[diagnostic(code(espup::toolchain::failed_to_create_difrectory))]
+    #[diagnostic(code(espup::toolchain::failed_to_create_directory))]
     #[error("{} Creating directory '{0}' failed", emoji::ERROR)]
     FailedToCreateDirectory(String),
     #[diagnostic(code(espup::toolchain::unsupported_file_extension))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ async fn install(args: InstallOpts) -> Result<()> {
                 let res = app.install().await;
                 if res.is_err() {
                     warn!(
-                        "{} Installation for '{}' failed, retriying",
+                        "{} Installation for '{}' failed, retrying",
                         emoji::WARN,
                         app.name()
                     );

--- a/src/toolchain/espidf.rs
+++ b/src/toolchain/espidf.rs
@@ -206,6 +206,10 @@ impl Installable for EspIdfRepo {
 
         Ok(exports)
     }
+
+    fn name(&self) -> String {
+        "ESP-IDF".to_string()
+    }
 }
 
 /// Gets the esp-idf installation path.

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -127,6 +127,10 @@ impl Installable for Gcc {
 
         Ok(exports)
     }
+
+    fn name(&self) -> String {
+        format!("GCC ({})", self.toolchain_name)
+    }
 }
 
 /// Gets the name of the GCC arch based on the host triple.

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -125,4 +125,8 @@ impl Installable for Llvm {
 
         Ok(exports)
     }
+
+    fn name(&self) -> String {
+        "LLVM".to_string()
+    }
 }

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -24,6 +24,7 @@ pub mod rust;
 pub trait Installable {
     /// Install some application, returning a vector of any required exports
     async fn install(&self) -> Result<Vec<String>, Error>;
+    /// Returns the name of the toolchain being installeds
     fn name(&self) -> String;
 }
 

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -172,9 +172,12 @@ impl Installable for XtensaRust {
         #[cfg(windows)]
         let toolchain_path = self.toolchain_destination.clone().join("esp");
         if toolchain_path.exists() {
-            return Err(Error::XtensaToolchainAlreadyInstalled(
-                toolchain_path.display().to_string(),
-            ));
+            warn!(
+                "{} Previous installation of Xtensa Rust exists in: '{}'. Reusing this installation.",
+                emoji::WARN,
+                &toolchain_path.display()
+            );
+            return Ok(vec![]);
         }
         info!(
             "{} Installing Xtensa Rust {} toolchain",
@@ -237,6 +240,10 @@ impl Installable for XtensaRust {
 
         Ok(vec![]) // No exports
     }
+
+    fn name(&self) -> String {
+        "Xtensa Rust".to_string()
+    }
 }
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Default)]
@@ -287,6 +294,10 @@ impl Installable for Crate {
         }
 
         Ok(vec![]) // No exports
+    }
+
+    fn name(&self) -> String {
+        format!("crate {}", self.name)
     }
 }
 
@@ -351,6 +362,10 @@ impl Installable for RiscVTarget {
         .output()?;
 
         Ok(vec![]) // No exports
+    }
+
+    fn name(&self) -> String {
+        "RISC-V rust target".to_string()
     }
 }
 


### PR DESCRIPTION
- When downloading a file, if the output file is already present, we delete and download it again
- Added a `name` method to the `Installable` trait
  - Implemented it for all the components
- Added retries to install
  - We now do 3 attempts of installing every component
- We no longer return `Err` if the Xtensa Toolchain is already present. Instead, we reuse the installation, see #138 
