### PR TITLE
Statically link `openssl` for all Unix targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,7 @@ async-trait = "0.1.61"
 retry = "2.0.0"
 tokio-retry = "0.3.0"
 
-
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Some users reported having issues on MacOs (#141) with `openssl` so I'm statically linking it for all Unix targets