### PR TITLE
 Improve `rust-src-nightly/install.sh` command

### DIFF
--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -216,7 +216,7 @@ impl Installable for XtensaRust {
             .await?;
             info!("{} Installing rust-src for esp toolchain", emoji::WRENCH);
             let arguments = format!(
-                "{}/rust-src-nightly/install.sh --destdir={} --prefix='' --without=rust-docs-json-preview,rust-docs --disable-ldconfig",
+                "{}/rust-src-nightly/install.sh --destdir={} --prefix='' --disable-ldconfig",
                 get_dist_path("rust-src"),
                 self.toolchain_destination.display()
             );


### PR DESCRIPTION
`rust-src-nightly/install.sh` only has one available component `rust-src`: 

```
$ ../.espressif/dist/rust-src/rust-src-nightly/install.sh --list-components

# Available components

* rust-src
```

So, it does not make any sense to filter `rust-docs-json-preview,rust-docs` components.