### PR TITLE
Simplify handling of extra crates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct Config {
     /// Destination of the generated export file.
     pub export_file: Option<PathBuf>,
     /// Extra crates to installed.
-    pub extra_crates: Option<HashSet<String>>,
+    pub extra_crates: HashSet<String>,
     /// Host triple
     pub host_triple: HostTriple,
     /// LLVM toolchain path.


### PR DESCRIPTION
Just a small tweak. Since collections implement `Default` it's sort of an anti-pattern to wrap them in an `Option` like this, as an empty set and `None` symbolize essentially the same thing in this context. This just cleans up the handling of the extra crates a bit.

~~For some reason the `InstallOpts` struct was being boxed as well, while the other subcommands were not, so I've just changed this.~~