### PR TITLE
Export CLANG_PATH so bindgen works with cross compilation

### DIFF
--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -30,7 +30,7 @@ pub struct Llvm {
     pub repository_url: String,
     /// LLVM Version ["15"].
     pub version: String,
-    /// True if only if the libraries were installed
+    /// If `true`, only libraries are installed.
     minified: bool,
 }
 
@@ -54,7 +54,7 @@ impl Llvm {
         let llvm_path = format!("{}/esp-clang/lib", self.path.to_str().unwrap());
         llvm_path
     }
-
+    /// Gets the binary path of clang
     fn get_bin_path(&self) -> String {
         #[cfg(windows)]
         let llvm_path = format!("{}/esp-clang/bin/clang.exe", self.path.to_str().unwrap());

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -30,6 +30,8 @@ pub struct Llvm {
     pub repository_url: String,
     /// LLVM Version ["15"].
     pub version: String,
+    /// True if only if the libraries were installed
+    minified: bool,
 }
 
 impl Llvm {
@@ -50,6 +52,14 @@ impl Llvm {
         let llvm_path = format!("{}/esp-clang/bin", self.path.to_str().unwrap());
         #[cfg(unix)]
         let llvm_path = format!("{}/esp-clang/lib", self.path.to_str().unwrap());
+        llvm_path
+    }
+
+    fn get_bin_path(&self) -> String {
+        #[cfg(windows)]
+        let llvm_path = format!("{}/esp-clang/bin/clang.exe", self.path.to_str().unwrap());
+        #[cfg(unix)]
+        let llvm_path = format!("{}/esp-clang/bin/clang", self.path.to_str().unwrap());
         llvm_path
     }
 
@@ -79,6 +89,7 @@ impl Llvm {
             path,
             repository_url,
             version,
+            minified,
         }
     }
 
@@ -122,6 +133,13 @@ impl Installable for Llvm {
         exports.push(format!("$Env:PATH += \";{}\"", self.get_lib_path()));
         #[cfg(unix)]
         exports.push(format!("export LIBCLANG_PATH=\"{}\"", self.get_lib_path()));
+
+        if !self.minified {
+            #[cfg(windows)]
+            exports.push(format!("$Env:CLANG_PATH = \"{}\"", self.get_bin_path()));
+            #[cfg(unix)]
+            exports.push(format!("export CLANG_PATH=\"{}\"", self.get_bin_path()));
+        }
 
         Ok(exports)
     }


### PR DESCRIPTION
Fixes #164

CLANG_PATH is relevant for bindgen to be able to find required headers and library files.  Without exporting this along with LIBCLANG_PATH, you'll get a mismatch using bindgen and if the host clang doesn't support full cross compilation of C code (which is common for Ubuntu in my case, at least), then ultimately bindgen will not be able to compile the code its trying to generate bindings for.  The user will see weird errors like basic types int16_t and such are missing or common header files like string.h aren't available.