### PR TITLE
fix: download Mac aarch64 versions of gcc

### DIFF
--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -141,7 +141,8 @@ impl Installable for Gcc {
 /// Gets the name of the GCC arch based on the host triple.
 fn get_arch(host_triple: &HostTriple) -> Result<&str> {
     match host_triple {
-        HostTriple::Aarch64AppleDarwin | HostTriple::X86_64AppleDarwin => Ok("macos"),
+        HostTriple::X86_64AppleDarwin => Ok("macos"),
+        HostTriple::Aarch64AppleDarwin => Ok("macos-arm64"),
         HostTriple::X86_64UnknownLinuxGnu => Ok("linux-amd64"),
         HostTriple::Aarch64UnknownLinuxGnu => Ok("linux-arm64"),
         HostTriple::X86_64PcWindowsMsvc | HostTriple::X86_64PcWindowsGnu => Ok("win64"),


### PR DESCRIPTION
Hey ! 

This PR makes `espup` download the aarch64 versions of the gcc tools on Macs with arm architecture instead of the x86_64 versions.