### PR TITLE
Add support for generating shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37686beaba5ac9f3ab01ee3172f792fc6ffdd685bfb9e63cfef02c0571a4e8e1"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +460,7 @@ dependencies = [
  "assert_fs",
  "async-trait",
  "clap",
+ "clap_complete",
  "console",
  "directories",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.64"
 
 [dependencies]
 async-trait = "0.1.67"
-clap = { version = "4.1.8", features = ["derive", "cargo"] }
+clap = { version = "4.1.8", features = ["derive"] }
 clap_complete = "4.1.5"
 console = "0.15.5"
 directories = "4.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ rust-version = "1.64"
 
 [dependencies]
 async-trait = "0.1.67"
-clap = { version = "4.1.8", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive", "cargo"] }
+clap_complete = "4.1.5"
 console = "0.15.5"
 directories = "4.0.1"
 env_logger = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ It's also possible to use [cargo-binstall](https://github.com/cargo-bins/cargo-b
 
 See [Usage](#usage) section for more details.
 
+### Completions
+
+```
+espup completions <SHELL> > <PATH_TO_STORE_COMPLETION>/espup.<SHELL_EXTENSION>
+```
+
 ### Install
 
 ```sh
@@ -98,14 +104,28 @@ espup update
 Usage: espup <COMMAND>
 
 Commands:
-  install    Installs Espressif Rust ecosystem
-  uninstall  Uninstalls Espressif Rust ecosystem
-  update     Updates Xtensa Rust toolchain
-  help       Print this message or the help of the given subcommand(s)
+  completions  Generate completions for the given shell
+  install      Installs Espressif Rust ecosystem
+  uninstall    Uninstalls Espressif Rust ecosystem
+  update       Updates Xtensa Rust toolchain
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help
   -V, --version  Print version
+```
+### Completions Subcommand
+
+```
+Usage: espup completions [OPTIONS] <SHELL>
+
+Arguments:
+  <SHELL>  Shell to generate completions for [possible values: bash, elvish, fish, powershell, zsh]
+
+Options:
+  -l, --log-level <LOG_LEVEL>  Verbosity level of the logs [default: info] [possible values: debug, info, warn, error]
+  -h, --help                   Print help
+  -V, --version                Print version
 ```
 
 ### Install Subcommand

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,12 +35,7 @@ const DEFAULT_EXPORT_FILE: &str = "export-esp.ps1";
 const DEFAULT_EXPORT_FILE: &str = "export-esp.sh";
 
 #[derive(Parser)]
-#[command(
-    version,
-    propagate_version = true,
-    about,
-    arg_required_else_help = true
-)]
+#[command(about, version)]
 struct Cli {
     #[command(subcommand)]
     subcommand: SubCommand,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_name, crate_version, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
 use directories::BaseDirs;
 use espup::{
@@ -36,9 +36,7 @@ const DEFAULT_EXPORT_FILE: &str = "export-esp.sh";
 
 #[derive(Parser)]
 #[command(
-    name = crate_name!(),
-    bin_name = crate_name!(),
-    version = crate_version!(),
+    version,
     propagate_version = true,
     about,
     arg_required_else_help = true
@@ -145,7 +143,7 @@ async fn completions(args: CompletionsOpts) -> Result<()> {
     clap_complete::generate(
         args.shell,
         &mut Cli::command(),
-        crate_name!(),
+        "espup",
         &mut std::io::stdout(),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,10 @@ pub enum SubCommand {
 
 #[derive(Debug, Parser)]
 pub struct CompletionsOpts {
+    /// Verbosity level of the logs.
+    #[arg(short = 'l', long, default_value = "info", value_parser = ["debug", "info", "warn", "error"])]
+    pub log_level: String,
+    /// Shell to generate completions for.
     pub shell: Shell,
 }
 
@@ -129,7 +133,14 @@ pub struct UninstallOpts {
 
 /// Updates Xtensa Rust toolchain.
 async fn completions(args: CompletionsOpts) -> Result<()> {
+    initialize_logger(&args.log_level);
     check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+
+    info!(
+        "{} Generating completions for {} shell",
+        emoji::DISC,
+        args.shell
+    );
 
     clap_complete::generate(
         args.shell,
@@ -137,6 +148,9 @@ async fn completions(args: CompletionsOpts) -> Result<()> {
         crate_name!(),
         &mut std::io::stdout(),
     );
+
+    info!("{} Completions successfully generated!", emoji::CHECK);
+
     Ok(())
 }
 


### PR DESCRIPTION
Uses `clap_complete` to generate shell completions. Usage example: 
```
espup completions bash > /usr/share/bash-completion/completions/espup.bash
```