### PR TITLE
Update LLVM and GCC

### DIFF
--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -16,8 +16,8 @@ use std::{
 };
 
 const DEFAULT_GCC_REPOSITORY: &str = "https://github.com/espressif/crosstool-NG/releases/download";
-const DEFAULT_GCC_RELEASE: &str = "esp-2021r2-patch5";
-const DEFAULT_GCC_VERSION: &str = "8_4_0";
+const DEFAULT_GCC_RELEASE: &str = "esp-12.2.0_20230208";
+const DEFAULT_GCC_VERSION: &str = "12.2.0_20230208";
 pub const ESP32_GCC: &str = "xtensa-esp32-elf";
 pub const ESP32S2_GCC: &str = "xtensa-esp32s2-elf";
 pub const ESP32S3_GCC: &str = "xtensa-esp32s3-elf";
@@ -29,14 +29,8 @@ pub struct Gcc {
     pub host_triple: HostTriple,
     /// GCC Toolchain name.
     pub name: String,
-    /// Repository release version to use.
-    pub release: String,
-    /// The repository containing GCC sources.
-    pub repository_url: String,
     /// GCC Toolchain path.
     pub path: PathBuf,
-    /// GCC Version.
-    pub version: String,
 }
 
 impl Gcc {
@@ -48,38 +42,24 @@ impl Gcc {
     /// Create a new instance with default values and proper toolchain name.
     pub fn new(target: &Target, host_triple: &HostTriple, toolchain_path: &Path) -> Self {
         let name = get_gcc_name(target);
-        let version = DEFAULT_GCC_VERSION.to_string();
-        let release = DEFAULT_GCC_RELEASE.to_string();
-        let path = toolchain_path
-            .join(&name)
-            .join(format!("{release}-{version}"));
+        let path = toolchain_path.join(&name).join(DEFAULT_GCC_RELEASE);
 
         Self {
             host_triple: host_triple.clone(),
             name,
-            release,
-            repository_url: DEFAULT_GCC_REPOSITORY.to_string(),
             path,
-            version,
         }
     }
 
     /// Create a new instance of RISC-V GCC with default values and proper toolchain name.
     pub fn new_riscv(host_triple: &HostTriple, toolchain_path: &Path) -> Self {
-        let version = DEFAULT_GCC_VERSION.to_string();
-        let release = DEFAULT_GCC_RELEASE.to_string();
         let name = RISCV_GCC.to_string();
-        let path = toolchain_path
-            .join(&name)
-            .join(format!("{release}-{version}"));
+        let path = toolchain_path.join(&name).join(DEFAULT_GCC_RELEASE);
 
         Self {
             host_triple: host_triple.clone(),
             name,
-            release,
-            repository_url: DEFAULT_GCC_REPOSITORY.to_string(),
             path,
-            version,
         }
     }
 }
@@ -97,14 +77,16 @@ impl Installable for Gcc {
             );
         } else {
             let gcc_file = format!(
-                "{}-gcc{}-{}-{}.{}",
+                "{}-{}-{}.{}",
                 self.name,
-                self.version,
-                self.release,
+                DEFAULT_GCC_VERSION,
                 get_arch(&self.host_triple).unwrap(),
                 extension
             );
-            let gcc_dist_url = format!("{}/{}/{}", self.repository_url, self.release, gcc_file);
+            let gcc_dist_url = format!(
+                "{}/{}/{}",
+                DEFAULT_GCC_REPOSITORY, DEFAULT_GCC_RELEASE, gcc_file
+            );
             download_file(
                 gcc_dist_url,
                 &format!("{}.{}", &self.name, extension),
@@ -141,11 +123,13 @@ impl Installable for Gcc {
 /// Gets the name of the GCC arch based on the host triple.
 fn get_arch(host_triple: &HostTriple) -> Result<&str> {
     match host_triple {
-        HostTriple::X86_64AppleDarwin => Ok("macos"),
-        HostTriple::Aarch64AppleDarwin => Ok("macos-arm64"),
-        HostTriple::X86_64UnknownLinuxGnu => Ok("linux-amd64"),
-        HostTriple::Aarch64UnknownLinuxGnu => Ok("linux-arm64"),
-        HostTriple::X86_64PcWindowsMsvc | HostTriple::X86_64PcWindowsGnu => Ok("win64"),
+        HostTriple::X86_64AppleDarwin => Ok("x86_64-apple-darwin"),
+        HostTriple::Aarch64AppleDarwin => Ok("aarch64-apple-darwin"),
+        HostTriple::X86_64UnknownLinuxGnu => Ok("x86_64-linux-gnu"),
+        HostTriple::Aarch64UnknownLinuxGnu => Ok("aarch64-linux-gnu"),
+        HostTriple::X86_64PcWindowsMsvc | HostTriple::X86_64PcWindowsGnu => {
+            Ok("x86_64-w64-mingw32")
+        }
     }
 }
 
@@ -153,7 +137,7 @@ fn get_arch(host_triple: &HostTriple) -> Result<&str> {
 fn get_artifact_extension(host_triple: &HostTriple) -> &str {
     match host_triple {
         HostTriple::X86_64PcWindowsMsvc | HostTriple::X86_64PcWindowsGnu => "zip",
-        _ => "tar.gz",
+        _ => "tar.xz",
     }
 }
 
@@ -180,10 +164,9 @@ pub fn uninstall_gcc_toolchains(toolchain_path: &Path) -> Result<(), Error> {
             #[cfg(windows)]
             if cfg!(windows) {
                 let gcc_path = format!(
-                    "{}\\{}-{}\\{}\\bin",
+                    "{}\\{}\\{}\\bin",
                     gcc_path.display(),
                     DEFAULT_GCC_RELEASE,
-                    DEFAULT_GCC_VERSION,
                     toolchain
                 );
                 std::env::set_var(

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -6,18 +6,21 @@ use crate::{
     emoji,
     error::Error,
     host_triple::HostTriple,
-    toolchain::{download_file, Installable},
+    toolchain::{download_file, rust::RE_EXTENDED_SEMANTIC_VERSION, Installable},
 };
 use async_trait::async_trait;
 use log::{info, warn};
 use miette::Result;
+use regex::Regex;
 use std::{
     fs::remove_dir_all,
     path::{Path, PathBuf},
+    u8,
 };
 
 const DEFAULT_LLVM_REPOSITORY: &str = "https://github.com/espressif/llvm-project/releases/download";
 const DEFAULT_LLVM_15_VERSION: &str = "esp-15.0.0-20221201";
+const DEFAULT_LLVM_16_VERSION: &str = "esp-16.0.0-20230515";
 pub const CLANG_NAME: &str = "xtensa-esp32-elf-clang";
 
 #[derive(Debug, Clone, Default)]
@@ -71,8 +74,28 @@ impl Llvm {
         toolchain_path: &Path,
         host_triple: &HostTriple,
         extended: bool,
+        xtensa_rust_version: &str,
     ) -> Result<Self, Error> {
-        let version = DEFAULT_LLVM_15_VERSION.to_string();
+        let re_extended: Regex = Regex::new(RE_EXTENDED_SEMANTIC_VERSION).unwrap();
+        let (major, minor, patch, subpatch) = match re_extended.captures(xtensa_rust_version) {
+            Some(version) => (
+                version.get(1).unwrap().as_str().parse::<u8>().unwrap(),
+                version.get(2).unwrap().as_str().parse::<u8>().unwrap(),
+                version.get(3).unwrap().as_str().parse::<u8>().unwrap(),
+                version.get(4).unwrap().as_str().parse::<u8>().unwrap(),
+            ),
+            None => return Err(Error::InvalidVersion(xtensa_rust_version.to_string())),
+        };
+
+        // Use LLVM 15 for versions 1.69.0.0 and below
+        let version = if (major == 1 && minor == 60 && patch == 0 && subpatch == 0)
+            || (major == 1 && minor < 60)
+        {
+            DEFAULT_LLVM_15_VERSION.to_string()
+        } else {
+            DEFAULT_LLVM_16_VERSION.to_string()
+        };
+
         let mut file_name = format!(
             "llvm-{}-{}.tar.xz",
             version,

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -34,7 +34,7 @@ const XTENSA_RUST_LATEST_API_URL: &str =
 const XTENSA_RUST_API_URL: &str = "https://api.github.com/repos/esp-rs/rust-build/releases";
 
 /// Xtensa Rust Toolchain version regex.
-const RE_EXTENDED_SEMANTIC_VERSION: &str = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)\.(?P<subpatch>0|[1-9]\d*)?$";
+pub const RE_EXTENDED_SEMANTIC_VERSION: &str = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)\.(?P<subpatch>0|[1-9]\d*)?$";
 const RE_SEMANTIC_VERSION: &str =
     r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)?$";
 


### PR DESCRIPTION
- Use [LLVM 16](https://github.com/espressif/llvm-project/releases/tag/esp-16.0.0-20230515)
- Use [GCC 12](https://github.com/espressif/crosstool-NG/releases/tag/esp-12.2.0_20230208)