### PR TITLE
Improve `remove_dir_all` errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     MissingRust,
 
     #[diagnostic(code(espup::remove_directory))]
-    #[error("{} Failed to remove '{0}' directory.", emoji::ERROR)]
+    #[error("{} Failed to remove '{0}'.", emoji::ERROR)]
     RemoveDirectory(String),
 
     #[error(transparent)]

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -179,7 +179,8 @@ pub fn uninstall_gcc_toolchains(toolchain_path: &Path) -> Result<(), Error> {
                         .replace(&format!("{gcc_path};"), ""),
                 );
             }
-            remove_dir_all(gcc_path)?;
+            remove_dir_all(&gcc_path)
+                .map_err(|_| Error::RemoveDirectory(gcc_path.display().to_string()))?;
         }
     }
 

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -136,7 +136,9 @@ impl Llvm {
                 );
                 set_environment_variable("PATH", &updated_path)?;
             }
-            remove_dir_all(toolchain_path.join(CLANG_NAME))?;
+            let path = toolchain_path.join(CLANG_NAME);
+            remove_dir_all(&path)
+                .map_err(|_| Error::RemoveDirectory(path.display().to_string()))?;
         }
         Ok(())
     }

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -65,7 +65,7 @@ pub async fn download_file(
             emoji::WRENCH,
             output_directory
         );
-        if let Err(_e) = create_dir_all(output_directory) {
+        if create_dir_all(output_directory).is_err() {
             return Err(Error::CreateDirectory(output_directory.to_string()));
         }
     }
@@ -136,10 +136,10 @@ pub async fn download_file(
         }
     } else {
         info!("{} Creating file: '{}'", emoji::WRENCH, file_path);
-        let mut out = File::create(file_path)?;
+        let mut out = File::create(&file_path)?;
         out.write_all(&bytes)?;
     }
-    Ok(format!("{output_directory}/{file_name}"))
+    Ok(file_path)
 }
 
 /// Installs or updates the Espressif Rust ecosystem.

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -165,7 +165,8 @@ impl XtensaRust {
                 && !subdir_name.contains(ESP32S3_GCC)
                 && !subdir_name.contains(CLANG_NAME)
             {
-                remove_dir_all(Path::new(&subdir_name)).unwrap();
+                remove_dir_all(Path::new(&subdir_name))
+                    .map_err(|_| Error::RemoveDirectory(subdir_name))?;
             }
         }
         Ok(())


### PR DESCRIPTION
Check if the `remove_dir_all` fn succeeds, if not, throw a descriptive error.