### PR TITLE
Add a flag to skip Xtensa Rust version parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Options:
 
           [default: nightly]
 
+  -k, --skip-version-parse
+          Skips parsing Xtensa Rust version
+
   -s, --std
           Only install toolchains required for STD applications.
 
@@ -195,15 +198,52 @@ Usage: espup update [OPTIONS]
 
 Options:
   -d, --default-host <DEFAULT_HOST>
-          Target triple of the host [possible values: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, x86_64-pc-windows-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
+          Target triple of the host
+
+          [possible values: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, x86_64-pc-windows-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
+
+  -f, --export-file <EXPORT_FILE>
+          Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
+
+  -e, --extended-llvm
+          Extends the LLVM installation.
+
+          This will install the whole LLVM instead of only installing the libs.
+
   -l, --log-level <LOG_LEVEL>
-          Verbosity level of the logs [default: info] [possible values: debug, info, warn, error]
+          Verbosity level of the logs
+
+          [default: info]
+          [possible values: debug, info, warn, error]
+
   -a, --name <NAME>
-          Xtensa Rust toolchain name [default: esp]
+          Xtensa Rust toolchain name
+
+          [default: esp]
+
+  -n, --nightly-version <NIGHTLY_VERSION>
+          Nightly Rust toolchain version
+
+          [default: nightly]
+
+  -k, --skip-version-parse
+          Skips parsing Xtensa Rust version
+
+  -s, --std
+          Only install toolchains required for STD applications.
+
+          With this option, espup will skip GCC installation (it will be handled by esp-idf-sys), hence you won't be able to build no_std applications.
+
+  -t, --targets <TARGETS>
+          Comma or space separated list of targets [esp32,esp32c2,esp32c3,esp32c6,esp32h2,esp32s2,esp32s3,all]
+
+          [default: all]
+
   -v, --toolchain-version <TOOLCHAIN_VERSION>
           Xtensa Rust toolchain version
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 
 ## License

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,4 @@
-use crate::{
-    targets::{parse_targets, Target},
-    toolchain::rust::XtensaRust,
-};
+use crate::targets::{parse_targets, Target};
 use clap::Parser;
 use clap_complete::Shell;
 use std::{collections::HashSet, path::PathBuf};
@@ -37,6 +34,9 @@ pub struct InstallOpts {
     /// Nightly Rust toolchain version.
     #[arg(short = 'n', long, default_value = "nightly")]
     pub nightly_version: String,
+    /// Skips parsing Xtensa Rust version.
+    #[arg(short = 'k', long)]
+    pub skip_version_parse: bool,
     /// Only install toolchains required for STD applications.
     ///
     /// With this option, espup will skip GCC installation (it will be handled by esp-idf-sys), hence you won't be able to build no_std applications.
@@ -46,7 +46,7 @@ pub struct InstallOpts {
     #[arg(short = 't', long, default_value = "all", value_parser = parse_targets)]
     pub targets: HashSet<Target>,
     /// Xtensa Rust toolchain version.
-    #[arg(short = 'v', long, value_parser = XtensaRust::parse_version)]
+    #[arg(short = 'v', long)]
     pub toolchain_version: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use espup::{
     logging::initialize_logger,
     toolchain::{
         gcc::uninstall_gcc_toolchains, install as toolchain_install, llvm::Llvm,
-        rust::get_rustup_home,
+        rust::get_rustup_home, rust::XtensaRust,
     },
     update::check_for_update,
 };
@@ -64,6 +64,13 @@ async fn install(args: InstallOpts) -> Result<()> {
     initialize_logger(&args.log_level);
     check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 
+    // Check if the toolchain version is valid if we are not skipping the version parse
+    if let Some(toolchain_version) = &args.toolchain_version {
+        if !args.skip_version_parse {
+            XtensaRust::parse_version(toolchain_version)?;
+        }
+    }
+
     info!("{} Installing the Espressif Rust ecosystem", emoji::DISC);
     toolchain_install(args).await?;
     info!("{} Installation successfully completed!", emoji::CHECK);
@@ -76,7 +83,6 @@ async fn uninstall(args: UninstallOpts) -> Result<()> {
     check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 
     info!("{} Uninstalling the Espressif Rust ecosystem", emoji::DISC);
-
     let install_path = get_rustup_home().join("toolchains").join(args.name);
 
     Llvm::uninstall(&install_path)?;
@@ -102,6 +108,13 @@ async fn uninstall(args: UninstallOpts) -> Result<()> {
 async fn update(args: InstallOpts) -> Result<()> {
     initialize_logger(&args.log_level);
     check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+
+    // Check if the toolchain version is valid if we are not skipping the version parse
+    if let Some(toolchain_version) = &args.toolchain_version {
+        if !args.skip_version_parse {
+            XtensaRust::parse_version(toolchain_version)?;
+        }
+    }
 
     info!("{} Updating Espressif Rust ecosystem", emoji::DISC);
     toolchain_install(args).await?;


### PR DESCRIPTION
If we provide the full Xtensa Rust version (with `-v/--toolchain_version`) and we use the new flag (-`k/--skip_version_parse`) the `XtensaRust::parse_version()` method, which causes some issues on CI, won't be called.