### PR TITLE
Setup user environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add automatically sourcing the environment files
+
 ### Fixed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add automatically sourcing the environment files
+- Setup user environment (#381)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "update-informer",
+ "winapi",
  "winreg 0.51.0",
  "xz2",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ openssl = { version = "0.10.57", features = ["vendored"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51.0"
+winapi =  { version = "0.3.9", features = ["winuser"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ Options:
 
 ### Install Subcommand
 
+> **Warning**
+>
+> #### Environment modification
+>  Installation will, by default, modify your environment. If you dont want `espup` to modify your environment, please use the `--no-modify-env` argument.
+
 > **Note**
 >
 > #### Xtensa Rust destination path
@@ -125,7 +130,7 @@ Options:
 > **Note**
 >
 > #### GitHub API
->  During the installation process, several GitHub queries are made, [which are subject to certain limits](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting). Our number of queries should not hit the limits unless you are running `espup install` command numerous times in a short span of time. We recommend setting the [`GITHUB_TOKEN` environment variable](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) when using `espup` in CI, if you want to use `espup` on CI, recommend using it via the [`xtensa-toolchain` action](https://github.com/esp-rs/xtensa-toolchain/), and making sure `GITHUB_TOKEN` is not set when using it on a host machine. See https://github.com/esp-rs/xtensa-toolchain/issues/15 for more details on this.
+>  During the installation process, several GitHub queries are made, [which are subject to certain limits](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting). Our number of queries should not hit the limit unless you are running `espup install` command numerous times in a short span of time. We recommend setting the [`GITHUB_TOKEN` environment variable](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) when using `espup` in CI, if you want to use `espup` on CI, recommend using it via the [`xtensa-toolchain` action](https://github.com/esp-rs/xtensa-toolchain/), and making sure `GITHUB_TOKEN` is not set when using it on a host machine. See https://github.com/esp-rs/xtensa-toolchain/issues/15 for more details on this.
 
 ```
 Usage: espup install [OPTIONS]
@@ -135,9 +140,6 @@ Options:
           Target triple of the host
 
           [possible values: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, x86_64-pc-windows-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
-
-  -f, --export-file <EXPORT_FILE>
-          Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
 
   -e, --extended-llvm
           Extends the LLVM installation.
@@ -159,6 +161,9 @@ Options:
           Nightly Rust toolchain version
 
           [default: nightly]
+
+  -o, --no-modify-env
+          Don't configure environment variables
 
   -k, --skip-version-parse
           Skips parsing Xtensa Rust version
@@ -202,9 +207,6 @@ Options:
 
           [possible values: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, x86_64-pc-windows-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
 
-  -f, --export-file <EXPORT_FILE>
-          Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
-
   -e, --extended-llvm
           Extends the LLVM installation.
 
@@ -225,6 +227,9 @@ Options:
           Nightly Rust toolchain version
 
           [default: nightly]
+
+  -o, --no-modify-env
+          Don't configure environment variables
 
   -k, --skip-version-parse
           Skips parsing Xtensa Rust version

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,9 @@ pub struct InstallOpts {
     /// Nightly Rust toolchain version.
     #[arg(short = 'n', long, default_value = "nightly")]
     pub nightly_version: String,
+    /// Don't configure environment variables
+    #[arg(short = 'o', long)]
+    pub no_modify_env: bool,
     /// Skips parsing Xtensa Rust version.
     #[arg(short = 'k', long)]
     pub skip_version_parse: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+//! Command line interface.
+
 use crate::targets::{parse_targets, Target};
 use clap::Parser;
 use clap_complete::Shell;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::targets::{parse_targets, Target};
 use clap::Parser;
 use clap_complete::Shell;
-use std::{collections::HashSet, path::PathBuf};
+use std::collections::HashSet;
 
 #[derive(Debug, Parser)]
 pub struct CompletionsOpts {
@@ -17,9 +17,6 @@ pub struct InstallOpts {
     /// Target triple of the host.
     #[arg(short = 'd', long, value_parser = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "x86_64-pc-windows-gnu" , "x86_64-apple-darwin" , "aarch64-apple-darwin"])]
     pub default_host: Option<String>,
-    /// Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html).
-    #[arg(short = 'f', long)]
-    pub export_file: Option<PathBuf>,
     /// Extends the LLVM installation.
     ///
     /// This will install the whole LLVM instead of only installing the libs.

--- a/src/env/env.bat
+++ b/src/env/env.bat
@@ -1,0 +1,32 @@
+@echo off
+rem espup CMD setup
+
+set XTENSA_GCC={xtensa_gcc}
+if not "%XTENSA_GCC%" == "" (
+    echo %PATH% | findstr /C:"%XTENSA_GCC%" 1>nul
+    if errorlevel 1 (
+        rem Prepending path
+        set PATH=%XTENSA_GCC%;%PATH%
+    )
+)
+
+set RISCV_GCC={riscv_gcc}
+if not "%RISCV_GCC%" == "" (
+    echo %PATH% | findstr /C:"%RISCV_GCC%" 1>nul
+    if errorlevel 1 (
+        rem Prepending path
+        set PATH=%RISCV_GCC%;%PATH%
+    )
+)
+
+set LIBCLANG_PATH={libclang_path}
+set LIBCLANG_BIN_PATH={libclang_bin_path}
+if not "%LIBCLANG_BIN_PATH%" == "" (
+    echo %PATH% | findstr /C:"%LIBCLANG_BIN_PATH%" 1>nul
+    if errorlevel 1 (
+        rem Prepending path
+        set PATH=%LIBCLANG_BIN_PATH%;%PATH%
+    )
+)
+
+set CLANG_PATH={clang_path}

--- a/src/env/env.fish
+++ b/src/env/env.fish
@@ -1,0 +1,12 @@
+# espup shell setup
+if not contains "{xtensa_gcc}" $PATH
+    # Prepending path in case a system-installed rustc needs to be overridden
+    set -x PATH "{xtensa_gcc}" $PATH
+end
+
+if not contains "{riscv_gcc}" $PATH
+    # Prepending path in case a system-installed rustc needs to be overridden
+    set -x PATH "{riscv_gcc}" $PATH
+end
+
+set -x LIBCLANG_PATH "{libclang}"

--- a/src/env/env.fish
+++ b/src/env/env.fish
@@ -2,7 +2,7 @@
 set XTENSA_GCC "{xtensa_gcc}"
 if test -n "$XTENSA_GCC"
     if not contains "{xtensa_gcc}" $PATH
-        # Prepending path in case a system-installed rustc needs to be overridden
+        # Prepending path
         set -x PATH "{xtensa_gcc}" $PATH
     end
 end
@@ -10,9 +10,10 @@ end
 set RISCV_GCC "{riscv_gcc}"
 if test -n "$RISCV_GCC"
     if not contains "{riscv_gcc}" $PATH
-        # Prepending path in case a system-installed rustc needs to be overridden
+        # Prepending path
         set -x PATH "{riscv_gcc}" $PATH
     end
 end
 
-set -x LIBCLANG_PATH "{libclang}"
+set -x LIBCLANG_PATH "{libclang_path}"
+set -x CLANG_PATH "{clang_path}"

--- a/src/env/env.fish
+++ b/src/env/env.fish
@@ -1,15 +1,18 @@
 # espup shell setup
-# TODO: WE NEED TO VERIFY THAT PLACEHOLDERS ARE REPLACED.
-# EG: USING THE --NO-STD FLAG WONT INSTALL GCC, HENCE WE WILL WRITE THE PATH WITH THE PLACEHOLDER
-
-if not contains "{xtensa_gcc}" $PATH
-    # Prepending path in case a system-installed rustc needs to be overridden
-    set -x PATH "{xtensa_gcc}" $PATH
+set XTENSA_GCC "{xtensa_gcc}"
+if test -n "$XTENSA_GCC"
+    if not contains "{xtensa_gcc}" $PATH
+        # Prepending path in case a system-installed rustc needs to be overridden
+        set -x PATH "{xtensa_gcc}" $PATH
+    end
 end
 
-if not contains "{riscv_gcc}" $PATH
-    # Prepending path in case a system-installed rustc needs to be overridden
-    set -x PATH "{riscv_gcc}" $PATH
+set RISCV_GCC "{riscv_gcc}"
+if test -n "$RISCV_GCC"
+    if not contains "{riscv_gcc}" $PATH
+        # Prepending path in case a system-installed rustc needs to be overridden
+        set -x PATH "{riscv_gcc}" $PATH
+    end
 end
 
 set -x LIBCLANG_PATH "{libclang}"

--- a/src/env/env.fish
+++ b/src/env/env.fish
@@ -1,4 +1,7 @@
 # espup shell setup
+# TODO: WE NEED TO VERIFY THAT PLACEHOLDERS ARE REPLACED.
+# EG: USING THE --NO-STD FLAG WONT INSTALL GCC, HENCE WE WILL WRITE THE PATH WITH THE PLACEHOLDER
+
 if not contains "{xtensa_gcc}" $PATH
     # Prepending path in case a system-installed rustc needs to be overridden
     set -x PATH "{xtensa_gcc}" $PATH

--- a/src/env/env.ps1
+++ b/src/env/env.ps1
@@ -1,0 +1,28 @@
+# espup PowerShell setup
+# affix semicolons on either side of $Env:PATH to simplify matching
+$XTENSA_GCC = "{xtensa_gcc}"
+if ($XTENSA_GCC -ne "") {
+    if (-not ($Env:PATH -like "*;$XTENSA_GCC;*")) {
+        # Prepending path
+        $Env:PATH = "$XTENSA_GCC;$Env:PATH"
+    }
+}
+
+$RISCV_GCC = "{riscv_gcc}"
+if ($RISCV_GCC -ne "") {
+    if (-not ($Env:PATH -like "*;$RISCV_GCC;*")) {
+        # Prepending path
+        $Env:PATH = "$RISCV_GCC;$Env:PATH"
+    }
+}
+
+$Env:LIBCLANG_PATH = "{libclang_path}"
+$LIBCLANG_BIN_PATH = "{libclang_bin_path}"
+if ($LIBCLANG_BIN_PATH -ne "") {
+    if (-not ($Env:PATH -like "*;$LIBCLANG_BIN_PATH;*")) {
+        # Prepending path
+        $Env:PATH = "$LIBCLANG_BIN_PATH;$Env:PATH"
+    }
+}
+
+$Env:CLANG_PATH = "{clang_path}"

--- a/src/env/env.sh
+++ b/src/env/env.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# espup shell setup
+# affix colons on either side of $PATH to simplify matching
+case ":${PATH}:" in
+*:"{xtensa_gcc}":*) ;;
+*)
+    # Prepending path in case a system-installed rustc needs to be overridden
+    export PATH="{xtensa_gcc}:$PATH"
+    ;;
+esac
+
+case ":${PATH}:" in
+*:"{riscv_gcc}":*) ;;
+*)
+    # Prepending path in case a system-installed rustc needs to be overridden
+    export PATH="{riscv_gcc}:$PATH"
+    ;;
+esac
+
+export LIBCLANG_PATH="{libclang_path}"

--- a/src/env/env.sh
+++ b/src/env/env.sh
@@ -1,20 +1,24 @@
 #!/bin/sh
 # espup shell setup
 # affix colons on either side of $PATH to simplify matching
-case ":${PATH}:" in
-*:"{xtensa_gcc}":*) ;;
-*)
-    # Prepending path in case a system-installed rustc needs to be overridden
-    export PATH="{xtensa_gcc}:$PATH"
-    ;;
-esac
-
-case ":${PATH}:" in
-*:"{riscv_gcc}":*) ;;
-*)
-    # Prepending path in case a system-installed rustc needs to be overridden
-    export PATH="{riscv_gcc}:$PATH"
-    ;;
-esac
-
+XTENSA_GCC="{xtensa_gcc}"
+if [[ -n "${XTENSA_GCC}" ]]; then
+    case ":${PATH}:" in
+    *:"{xtensa_gcc}":*) ;;
+    *)
+        # Prepending path in case a system-installed rustc needs to be overridden
+        export PATH="{xtensa_gcc}:$PATH"
+        ;;
+    esac
+fi
+RISCV_GCC="{riscv_gcc}"
+if [[ -n "${RISCV_GCC}" ]]; then
+    case ":${PATH}:" in
+    *:"{riscv_gcc}":*) ;;
+    *)
+        # Prepending path in case a system-installed rustc needs to be overridden
+        export PATH="{riscv_gcc}:$PATH"
+        ;;
+    esac
+fi
 export LIBCLANG_PATH="{libclang_path}"

--- a/src/env/env.sh
+++ b/src/env/env.sh
@@ -6,7 +6,7 @@ if [[ -n "${XTENSA_GCC}" ]]; then
     case ":${PATH}:" in
     *:"{xtensa_gcc}":*) ;;
     *)
-        # Prepending path in case a system-installed rustc needs to be overridden
+        # Prepending path
         export PATH="{xtensa_gcc}:$PATH"
         ;;
     esac
@@ -16,9 +16,10 @@ if [[ -n "${RISCV_GCC}" ]]; then
     case ":${PATH}:" in
     *:"{riscv_gcc}":*) ;;
     *)
-        # Prepending path in case a system-installed rustc needs to be overridden
+        # Prepending path
         export PATH="{riscv_gcc}:$PATH"
         ;;
     esac
 fi
 export LIBCLANG_PATH="{libclang_path}"
+export CLANG_PATH="{clang_path}"

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -22,7 +22,7 @@ const DEFAULT_EXPORT_FILE: &str = "export-esp.sh";
 /// Returns the absolute path to the export file, uses the DEFAULT_EXPORT_FILE if no arg is provided.
 pub fn get_export_file(
     export_file: Option<PathBuf>,
-    toolchain_dir: &PathBuf,
+    toolchain_dir: &Path,
 ) -> Result<PathBuf, Error> {
     if let Some(export_file) = export_file {
         if export_file.is_dir() {
@@ -54,7 +54,7 @@ pub fn create_export_file(export_file: &PathBuf, exports: &[String]) -> Result<(
 }
 
 /// Instructions to export the environment variables.
-pub fn export_environment(export_file: &Path, toolchain_dir: &PathBuf) -> Result<(), Error> {
+pub fn export_environment(export_file: &Path, toolchain_dir: &Path) -> Result<(), Error> {
     #[cfg(windows)]
     if cfg!(windows) {
         set_environment_variable("PATH", &env::var("PATH").unwrap())?;

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -55,6 +55,6 @@ pub fn print_post_install_msg(toolchain_dir: &str, no_modify_env: bool) {
     #[cfg(windows)]
     println!(
         "\t'. {}\\env.ps1' or '{}\\env.bat dependeing on your shell'",
-        toolchain_dir
+        toolchain_dir, toolchain_dir
     );
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -21,7 +21,10 @@ const DEFAULT_EXPORT_FILE: &str = "export-esp.ps1";
 const DEFAULT_EXPORT_FILE: &str = "export-esp.sh";
 
 /// Returns the absolute path to the export file, uses the DEFAULT_EXPORT_FILE if no arg is provided.
-pub fn get_export_file(export_file: Option<PathBuf>) -> Result<PathBuf, Error> {
+pub fn get_export_file(
+    export_file: Option<PathBuf>,
+    toolchain_dir: &PathBuf,
+) -> Result<PathBuf, Error> {
     if let Some(export_file) = export_file {
         if export_file.is_dir() {
             return Err(Error::InvalidDestination(export_file.display().to_string()));
@@ -33,10 +36,7 @@ pub fn get_export_file(export_file: Option<PathBuf>) -> Result<PathBuf, Error> {
             Ok(current_dir.join(export_file))
         }
     } else {
-        Ok(BaseDirs::new()
-            .unwrap()
-            .home_dir()
-            .join(DEFAULT_EXPORT_FILE))
+        Ok(toolchain_dir.join(DEFAULT_EXPORT_FILE))
     }
 }
 
@@ -55,7 +55,7 @@ pub fn create_export_file(export_file: &PathBuf, exports: &[String]) -> Result<(
 }
 
 /// Instructions to export the environment variables.
-pub fn export_environment(export_file: &Path) -> Result<(), Error> {
+pub fn export_environment(export_file: &Path, toolchain_dir: &PathBuf) -> Result<(), Error> {
     #[cfg(windows)]
     if cfg!(windows) {
         set_environment_variable("PATH", &env::var("PATH").unwrap())?;
@@ -72,7 +72,7 @@ pub fn export_environment(export_file: &Path) -> Result<(), Error> {
         let source_command = format!(". {}", export_file.display());
 
         // Check if the GCC_RISCV environment variable is set
-
+        unix::do_write_env_files(toolchain_dir)?;
         // let profile = BaseDirs::new().unwrap().home_dir().join(".profile");
         // let bashrc = BaseDirs::new().unwrap().home_dir().join(".bashrc");
         // let rcs = vec![profile, bashrc];

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -28,10 +28,12 @@ pub fn set_env(toolchain_dir: &Path, no_modify_env: bool) -> Result<(), Error> {
     Ok(())
 }
 
+/// Get the home directory.
 pub fn get_home_dir() -> PathBuf {
     BaseDirs::new().unwrap().home_dir().to_path_buf()
 }
 
+/// Clean the environment variables.
 pub fn clean_env(install_dir: &Path) -> Result<(), Error> {
     #[cfg(windows)]
     windows::clean_env(install_dir)?;
@@ -40,6 +42,8 @@ pub fn clean_env(install_dir: &Path) -> Result<(), Error> {
 
     Ok(())
 }
+
+/// Print to post installation message
 pub fn print_post_install_msg(toolchain_dir: &str, no_modify_env: bool) {
     if no_modify_env {
         println!(

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -52,9 +52,12 @@ pub fn get_export_file(
 
 /// Instructions to export the environment variables.
 pub fn set_environment(toolchain_dir: &Path) -> Result<(), Error> {
+    // TODO: UNIFY do_write_env_files and do_add_to_path and then have a common function that does the checking of OS
+    // TODO: RENAME do_write_env_files and do_add_to_path methods
     #[cfg(windows)]
     if cfg!(windows) {
         set_environment_variable("PATH", &env::var("PATH").unwrap())?;
+        windows::do_write_env_files(toolchain_dir)?;
     }
     #[cfg(unix)]
     if cfg!(unix) {

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -3,6 +3,7 @@
 use crate::error::Error;
 use directories::BaseDirs;
 use log::info;
+use miette::Result;
 use std::{
     fs::File,
     io::Write,
@@ -86,7 +87,7 @@ pub fn export_environment(export_file: &Path, toolchain_dir: &Path) -> Result<()
 }
 
 pub fn get_home_dir() -> PathBuf {
-    BaseDirs::new().unwrap().home_dir().into()
+    BaseDirs::new().unwrap().home_dir().to_path_buf()
 }
 
 // #[cfg(test)]
@@ -101,22 +102,26 @@ pub fn get_home_dir() -> PathBuf {
 //         // No arg provided
 //         let home_dir = BaseDirs::new().unwrap().home_dir().to_path_buf();
 //         let export_file = home_dir.join(DEFAULT_EXPORT_FILE);
-//         assert!(matches!(get_export_file(None), Ok(export_file)));
+//         let toolchain_dir = home_dir.join(".rustup").join("toolchains").join("esp");
+//         assert!(matches!(
+//             get_export_file(None, &toolchain_dir),
+//             Ok(export_file)
+//         ));
 //         // Relative path
 //         let current_dir = current_dir().unwrap();
 //         let export_file = current_dir.join("export.sh");
 //         assert!(matches!(
-//             get_export_file(Some(PathBuf::from("export.sh"))),
+//             get_export_file(Some(PathBuf::from("export.sh")), &toolchain_dir),
 //             Ok(export_file)
 //         ));
 //         // Absolute path
 //         let export_file = PathBuf::from("/home/user/export.sh");
 //         assert!(matches!(
-//             get_export_file(Some(PathBuf::from("/home/user/export.sh"))),
+//             get_export_file(Some(PathBuf::from("/home/user/export.sh")), &toolchain_dir),
 //             Ok(export_file)
 //         ));
 //         // Path is a directory instead of a file
-//         assert!(get_export_file(Some(home_dir)).is_err());
+//         assert!(get_export_file(Some(home_dir), &toolchain_dir).is_err());
 //     }
 
 //     #[test]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -2,13 +2,8 @@
 
 use crate::error::Error;
 use directories::BaseDirs;
-use log::info;
 use miette::Result;
-use std::{
-    fs::File,
-    io::Write,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 pub mod shell;
 #[cfg(unix)]
@@ -56,17 +51,10 @@ pub fn get_export_file(
 // }
 
 /// Instructions to export the environment variables.
-pub fn export_environment(export_file: &Path, toolchain_dir: &Path) -> Result<(), Error> {
+pub fn set_environment(toolchain_dir: &Path) -> Result<(), Error> {
     #[cfg(windows)]
     if cfg!(windows) {
         set_environment_variable("PATH", &env::var("PATH").unwrap())?;
-        warn!(
-            "Your environments variables have been updated! Shell may need to be restarted for changes to be effective"
-        );
-        warn!(
-            "A file was created at '{}' showing the injected environment variables",
-            export_file.display()
-        );
     }
     #[cfg(unix)]
     if cfg!(unix) {
@@ -79,6 +67,24 @@ pub fn export_environment(export_file: &Path, toolchain_dir: &Path) -> Result<()
 
 pub fn get_home_dir() -> PathBuf {
     BaseDirs::new().unwrap().home_dir().to_path_buf()
+}
+
+pub fn print_post_install_msg(toolchain_dir: &str, no_modify_env: bool) {
+    if no_modify_env {
+        println!(
+            "\tTo get started you need to configure some environment variable. This has not been done automatically."
+        );
+    } else {
+        println!("\tTo get started you may need to restart your current shell.");
+    }
+    println!("\tTo configure your current shell, run:");
+    #[cfg(unix)]
+    println!(
+        "\t'. {}/env' or '. {}/env.fish' depending on your shell",
+        toolchain_dir, toolchain_dir
+    );
+    #[cfg(windows)]
+    println!("\t'. {}\\export-esp.ps1'", toolchain_dir);
 }
 
 // #[cfg(test)]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -42,18 +42,18 @@ pub fn get_export_file(
 }
 
 /// Creates the export file with the necessary environment variables.
-pub fn create_export_file(export_file: &PathBuf, exports: &[String]) -> Result<(), Error> {
-    info!("Creating export file");
-    let mut file = File::create(export_file)?;
-    for e in exports.iter() {
-        #[cfg(windows)]
-        let e = e.replace('/', r"\");
-        file.write_all(e.as_bytes())?;
-        file.write_all(b"\n")?;
-    }
+// pub fn create_export_file(export_file: &PathBuf, exports: &[String]) -> Result<(), Error> {
+//     info!("Creating export file");
+//     let mut file = File::create(export_file)?;
+//     for e in exports.iter() {
+//         #[cfg(windows)]
+//         let e = e.replace('/', r"\");
+//         file.write_all(e.as_bytes())?;
+//         file.write_all(b"\n")?;
+//     }
 
-    Ok(())
-}
+//     Ok(())
+// }
 
 /// Instructions to export the environment variables.
 pub fn export_environment(export_file: &Path, toolchain_dir: &Path) -> Result<(), Error> {
@@ -70,18 +70,9 @@ pub fn export_environment(export_file: &Path, toolchain_dir: &Path) -> Result<()
     }
     #[cfg(unix)]
     if cfg!(unix) {
-        let source_command = format!(". {}", export_file.display());
-
         // Check if the GCC_RISCV environment variable is set
         unix::do_write_env_files(toolchain_dir)?;
         unix::do_add_to_path(toolchain_dir)?;
-        println!(
-            "\n\tTo get started, you need to set up some environment variables by running: '{}'",
-            source_command
-        );
-        println!(
-            "\tThis step must be done every time you open a new terminal.\n\t    See other methods for setting the environment in https://esp-rs.github.io/book/installation/riscv-and-xtensa.html#3-set-up-the-environment-variables",
-        );
     }
     Ok(())
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,7 +1,6 @@
 //! Environment variables set up and export file support.
 
 use crate::error::Error;
-use directories::BaseDirs;
 use log::info;
 use std::{
     fs::File,
@@ -73,19 +72,7 @@ pub fn export_environment(export_file: &Path, toolchain_dir: &PathBuf) -> Result
 
         // Check if the GCC_RISCV environment variable is set
         unix::do_write_env_files(toolchain_dir)?;
-        // let profile = BaseDirs::new().unwrap().home_dir().join(".profile");
-        // let bashrc = BaseDirs::new().unwrap().home_dir().join(".bashrc");
-        // let rcs = vec![profile, bashrc];
-        // for rc in rcs {
-        //     if rc.exists() {
-        //         let mut file = OpenOptions::new()
-        //             .write(true)
-        //             .append(true)
-        //             .open(rc)
-        //             .unwrap();
-        //         writeln!(file, "{}", source_command)?;
-        //     }
-        // }
+        unix::do_add_to_path(toolchain_dir)?;
         println!(
             "\n\tTo get started, you need to set up some environment variables by running: '{}'",
             source_command
@@ -97,57 +84,57 @@ pub fn export_environment(export_file: &Path, toolchain_dir: &PathBuf) -> Result
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::env::{create_export_file, get_export_file, DEFAULT_EXPORT_FILE};
-    use directories::BaseDirs;
-    use std::{env::current_dir, path::PathBuf};
+// #[cfg(test)]
+// mod tests {
+//     use crate::env::{create_export_file, get_export_file, DEFAULT_EXPORT_FILE};
+//     use directories::BaseDirs;
+//     use std::{env::current_dir, path::PathBuf};
 
-    #[test]
-    #[allow(unused_variables)]
-    fn test_get_export_file() {
-        // No arg provided
-        let home_dir = BaseDirs::new().unwrap().home_dir().to_path_buf();
-        let export_file = home_dir.join(DEFAULT_EXPORT_FILE);
-        assert!(matches!(get_export_file(None), Ok(export_file)));
-        // Relative path
-        let current_dir = current_dir().unwrap();
-        let export_file = current_dir.join("export.sh");
-        assert!(matches!(
-            get_export_file(Some(PathBuf::from("export.sh"))),
-            Ok(export_file)
-        ));
-        // Absolute path
-        let export_file = PathBuf::from("/home/user/export.sh");
-        assert!(matches!(
-            get_export_file(Some(PathBuf::from("/home/user/export.sh"))),
-            Ok(export_file)
-        ));
-        // Path is a directory instead of a file
-        assert!(get_export_file(Some(home_dir)).is_err());
-    }
+//     #[test]
+//     #[allow(unused_variables)]
+//     fn test_get_export_file() {
+//         // No arg provided
+//         let home_dir = BaseDirs::new().unwrap().home_dir().to_path_buf();
+//         let export_file = home_dir.join(DEFAULT_EXPORT_FILE);
+//         assert!(matches!(get_export_file(None), Ok(export_file)));
+//         // Relative path
+//         let current_dir = current_dir().unwrap();
+//         let export_file = current_dir.join("export.sh");
+//         assert!(matches!(
+//             get_export_file(Some(PathBuf::from("export.sh"))),
+//             Ok(export_file)
+//         ));
+//         // Absolute path
+//         let export_file = PathBuf::from("/home/user/export.sh");
+//         assert!(matches!(
+//             get_export_file(Some(PathBuf::from("/home/user/export.sh"))),
+//             Ok(export_file)
+//         ));
+//         // Path is a directory instead of a file
+//         assert!(get_export_file(Some(home_dir)).is_err());
+//     }
 
-    #[test]
-    fn test_create_export_file() {
-        // Creates the export file and writes the correct content to it
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let export_file = temp_dir.path().join("export.sh");
-        let exports = vec![
-            "export VAR1=value1".to_string(),
-            "export VAR2=value2".to_string(),
-        ];
-        create_export_file(&export_file, &exports).unwrap();
-        let contents = std::fs::read_to_string(export_file).unwrap();
-        assert_eq!(contents, "export VAR1=value1\nexport VAR2=value2\n");
+//     #[test]
+//     fn test_create_export_file() {
+//         // Creates the export file and writes the correct content to it
+//         let temp_dir = tempfile::TempDir::new().unwrap();
+//         let export_file = temp_dir.path().join("export.sh");
+//         let exports = vec![
+//             "export VAR1=value1".to_string(),
+//             "export VAR2=value2".to_string(),
+//         ];
+//         create_export_file(&export_file, &exports).unwrap();
+//         let contents = std::fs::read_to_string(export_file).unwrap();
+//         assert_eq!(contents, "export VAR1=value1\nexport VAR2=value2\n");
 
-        // Returns the correct error when it fails to create the export file (it already exists)
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let export_file = temp_dir.path().join("export.sh");
-        std::fs::create_dir_all(&export_file).unwrap();
-        let exports = vec![
-            "export VAR1=value1".to_string(),
-            "export VAR2=value2".to_string(),
-        ];
-        assert!(create_export_file(&export_file, &exports).is_err());
-    }
-}
+//         // Returns the correct error when it fails to create the export file (it already exists)
+//         let temp_dir = tempfile::TempDir::new().unwrap();
+//         let export_file = temp_dir.path().join("export.sh");
+//         std::fs::create_dir_all(&export_file).unwrap();
+//         let exports = vec![
+//             "export VAR1=value1".to_string(),
+//             "export VAR2=value2".to_string(),
+//         ];
+//         assert!(create_export_file(&export_file, &exports).is_err());
+//     }
+// }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -56,7 +56,7 @@ pub fn print_post_install_msg(toolchain_dir: &str, no_modify_env: bool) {
     );
     #[cfg(windows)]
     println!(
-        "\t'. {}\\env.ps1' or '{}\\env.bat' depending on your shell'",
+        "\t'. {}\\env.ps1' or '{}\\env.bat' depending on your shell",
         toolchain_dir, toolchain_dir
     );
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -12,17 +12,19 @@ pub mod unix;
 pub mod windows;
 
 /// Instructions to export the environment variables.
-pub fn set_env(toolchain_dir: &Path) -> Result<(), Error> {
+pub fn set_env(toolchain_dir: &Path, no_modify_env: bool) -> Result<(), Error> {
     #[cfg(windows)]
-    if cfg!(windows) {
-        windows::write_env_files(toolchain_dir)?;
-        windows::update_env()?;
-    }
+    windows::write_env_files(toolchain_dir)?;
     #[cfg(unix)]
-    if cfg!(unix) {
-        unix::write_env_files(toolchain_dir)?;
+    unix::write_env_files(toolchain_dir)?;
+
+    if !no_modify_env {
+        #[cfg(windows)]
+        windows::update_env()?;
+        #[cfg(unix)]
         unix::update_env(toolchain_dir)?;
     }
+
     Ok(())
 }
 
@@ -54,7 +56,7 @@ pub fn print_post_install_msg(toolchain_dir: &str, no_modify_env: bool) {
     );
     #[cfg(windows)]
     println!(
-        "\t'. {}\\env.ps1' or '{}\\env.bat dependeing on your shell'",
+        "\t'. {}\\env.ps1' or '{}\\env.bat' depending on your shell'",
         toolchain_dir, toolchain_dir
     );
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,4 +1,4 @@
-//! Environment variables set up and export file support.
+//! Environment variables set up and environment file support.
 
 use crate::error::Error;
 use directories::BaseDirs;
@@ -10,45 +10,6 @@ pub mod shell;
 pub mod unix;
 #[cfg(windows)]
 pub mod windows;
-
-#[cfg(windows)]
-const DEFAULT_EXPORT_FILE: &str = "export-esp.ps1";
-#[cfg(unix)]
-const DEFAULT_EXPORT_FILE: &str = "export-esp.sh";
-
-/// Returns the absolute path to the export file, uses the DEFAULT_EXPORT_FILE if no arg is provided.
-pub fn get_export_file(
-    export_file: Option<PathBuf>,
-    toolchain_dir: &Path,
-) -> Result<PathBuf, Error> {
-    if let Some(export_file) = export_file {
-        if export_file.is_dir() {
-            return Err(Error::InvalidDestination(export_file.display().to_string()));
-        }
-        if export_file.is_absolute() {
-            Ok(export_file)
-        } else {
-            let current_dir = std::env::current_dir()?;
-            Ok(current_dir.join(export_file))
-        }
-    } else {
-        Ok(toolchain_dir.join(DEFAULT_EXPORT_FILE))
-    }
-}
-
-/// Creates the export file with the necessary environment variables.
-// pub fn create_export_file(export_file: &PathBuf, exports: &[String]) -> Result<(), Error> {
-//     info!("Creating export file");
-//     let mut file = File::create(export_file)?;
-//     for e in exports.iter() {
-//         #[cfg(windows)]
-//         let e = e.replace('/', r"\");
-//         file.write_all(e.as_bytes())?;
-//         file.write_all(b"\n")?;
-//     }
-
-//     Ok(())
-// }
 
 /// Instructions to export the environment variables.
 pub fn set_environment(toolchain_dir: &Path) -> Result<(), Error> {
@@ -87,64 +48,8 @@ pub fn print_post_install_msg(toolchain_dir: &str, no_modify_env: bool) {
         toolchain_dir, toolchain_dir
     );
     #[cfg(windows)]
-    println!("\t'. {}\\export-esp.ps1'", toolchain_dir);
+    println!(
+        "\t'. {}\\env.ps1' or '{}\\env.bat dependeing on your shell'",
+        toolchain_dir
+    );
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use crate::env::{create_export_file, get_export_file, DEFAULT_EXPORT_FILE};
-//     use directories::BaseDirs;
-//     use std::{env::current_dir, path::PathBuf};
-
-//     #[test]
-//     #[allow(unused_variables)]
-//     fn test_get_export_file() {
-//         // No arg provided
-//         let home_dir = BaseDirs::new().unwrap().home_dir().to_path_buf();
-//         let export_file = home_dir.join(DEFAULT_EXPORT_FILE);
-//         let toolchain_dir = home_dir.join(".rustup").join("toolchains").join("esp");
-//         assert!(matches!(
-//             get_export_file(None, &toolchain_dir),
-//             Ok(export_file)
-//         ));
-//         // Relative path
-//         let current_dir = current_dir().unwrap();
-//         let export_file = current_dir.join("export.sh");
-//         assert!(matches!(
-//             get_export_file(Some(PathBuf::from("export.sh")), &toolchain_dir),
-//             Ok(export_file)
-//         ));
-//         // Absolute path
-//         let export_file = PathBuf::from("/home/user/export.sh");
-//         assert!(matches!(
-//             get_export_file(Some(PathBuf::from("/home/user/export.sh")), &toolchain_dir),
-//             Ok(export_file)
-//         ));
-//         // Path is a directory instead of a file
-//         assert!(get_export_file(Some(home_dir), &toolchain_dir).is_err());
-//     }
-
-//     #[test]
-//     fn test_create_export_file() {
-//         // Creates the export file and writes the correct content to it
-//         let temp_dir = tempfile::TempDir::new().unwrap();
-//         let export_file = temp_dir.path().join("export.sh");
-//         let exports = vec![
-//             "export VAR1=value1".to_string(),
-//             "export VAR2=value2".to_string(),
-//         ];
-//         create_export_file(&export_file, &exports).unwrap();
-//         let contents = std::fs::read_to_string(export_file).unwrap();
-//         assert_eq!(contents, "export VAR1=value1\nexport VAR2=value2\n");
-
-//         // Returns the correct error when it fails to create the export file (it already exists)
-//         let temp_dir = tempfile::TempDir::new().unwrap();
-//         let export_file = temp_dir.path().join("export.sh");
-//         std::fs::create_dir_all(&export_file).unwrap();
-//         let exports = vec![
-//             "export VAR1=value1".to_string(),
-//             "export VAR2=value2".to_string(),
-//         ];
-//         assert!(create_export_file(&export_file, &exports).is_err());
-//     }
-// }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -30,6 +30,14 @@ pub fn get_home_dir() -> PathBuf {
     BaseDirs::new().unwrap().home_dir().to_path_buf()
 }
 
+pub fn clean_env(install_dir: &Path) -> Result<(), Error> {
+    #[cfg(windows)]
+    windows::clean_env(install_dir)?;
+    #[cfg(unix)]
+    unix::clean_env(install_dir)?;
+
+    Ok(())
+}
 pub fn print_post_install_msg(toolchain_dir: &str, no_modify_env: bool) {
     if no_modify_env {
         println!(

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,6 +1,7 @@
 //! Environment variables set up and export file support.
 
 use crate::error::Error;
+use directories::BaseDirs;
 use log::info;
 use std::{
     fs::File,
@@ -82,6 +83,10 @@ pub fn export_environment(export_file: &Path, toolchain_dir: &Path) -> Result<()
         );
     }
     Ok(())
+}
+
+pub fn get_home_dir() -> PathBuf {
+    BaseDirs::new().unwrap().home_dir().into()
 }
 
 // #[cfg(test)]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -12,7 +12,7 @@ pub mod unix;
 pub mod windows;
 
 /// Instructions to export the environment variables.
-pub fn set_environment(toolchain_dir: &Path) -> Result<(), Error> {
+pub fn set_env(toolchain_dir: &Path) -> Result<(), Error> {
     #[cfg(windows)]
     if cfg!(windows) {
         windows::write_env_files(toolchain_dir)?;

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -7,6 +7,8 @@ use log::info;
 use log::warn;
 #[cfg(windows)]
 use std::env;
+#[cfg(unix)]
+use std::fs::OpenOptions;
 use std::{
     fs::File,
     io::Write,
@@ -18,11 +20,14 @@ use winreg::{
     RegKey,
 };
 
+pub mod shell;
+
 #[cfg(windows)]
 const DEFAULT_EXPORT_FILE: &str = "export-esp.ps1";
 #[cfg(not(windows))]
 const DEFAULT_EXPORT_FILE: &str = "export-esp.sh";
 
+// TODO: Move this to a windows.rs file
 #[cfg(windows)]
 /// Sets an environment variable for the current user.
 pub fn set_environment_variable(key: &str, value: &str) -> Result<(), Error> {
@@ -98,9 +103,23 @@ pub fn export_environment(export_file: &Path) -> Result<(), Error> {
     }
     #[cfg(unix)]
     if cfg!(unix) {
+        let source_command = format!(". {}", export_file.display());
+        // let profile = BaseDirs::new().unwrap().home_dir().join(".profile");
+        // let bashrc = BaseDirs::new().unwrap().home_dir().join(".bashrc");
+        // let rcs = vec![profile, bashrc];
+        // for rc in rcs {
+        //     if rc.exists() {
+        //         let mut file = OpenOptions::new()
+        //             .write(true)
+        //             .append(true)
+        //             .open(rc)
+        //             .unwrap();
+        //         writeln!(file, "{}", source_command)?;
+        //     }
+        // }
         println!(
-            "\n\tTo get started, you need to set up some environment variables by running: '. {}'",
-            export_file.display()
+            "\n\tTo get started, you need to set up some environment variables by running: '{}'",
+            source_command
         );
         println!(
             "\tThis step must be done every time you open a new terminal.\n\t    See other methods for setting the environment in https://esp-rs.github.io/book/installation/riscv-and-xtensa.html#3-set-up-the-environment-variables",

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -13,18 +13,15 @@ pub mod windows;
 
 /// Instructions to export the environment variables.
 pub fn set_environment(toolchain_dir: &Path) -> Result<(), Error> {
-    // TODO: UNIFY do_write_env_files and do_add_to_path and then have a common function that does the checking of OS
-    // TODO: RENAME do_write_env_files and do_add_to_path methods
     #[cfg(windows)]
     if cfg!(windows) {
-        set_environment_variable("PATH", &env::var("PATH").unwrap())?;
-        windows::do_write_env_files(toolchain_dir)?;
+        windows::write_env_files(toolchain_dir)?;
+        windows::update_env(toolchain_dir)?;
     }
     #[cfg(unix)]
     if cfg!(unix) {
-        // Check if the GCC_RISCV environment variable is set
-        unix::do_write_env_files(toolchain_dir)?;
-        unix::do_add_to_path(toolchain_dir)?;
+        unix::write_env_files(toolchain_dir)?;
+        unix::update_env(toolchain_dir)?;
     }
     Ok(())
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -16,7 +16,7 @@ pub fn set_env(toolchain_dir: &Path) -> Result<(), Error> {
     #[cfg(windows)]
     if cfg!(windows) {
         windows::write_env_files(toolchain_dir)?;
-        windows::update_env(toolchain_dir)?;
+        windows::update_env()?;
     }
     #[cfg(unix)]
     if cfg!(unix) {

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -25,6 +25,8 @@
 //! 1) using a shell script that updates PATH if the path is not in PATH
 //! 2) sourcing this script (`. /path/to/script`) in any appropriate rc file
 
+#[cfg(unix)]
+use crate::env::get_home_dir;
 use crate::error::Error;
 use miette::Result;
 use std::{

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -44,22 +44,16 @@ impl ShellScript {
     pub(crate) fn write(&self) -> Result<()> {
         let env_file_path = self.toolchain_dir.join(self.name);
         let mut env_file: String = self.content.to_string();
-        if std::env::var("XTENSA_GCC").is_ok() {
-            env_file = env_file.replace(
-                "{xtensa_gcc}",
-                std::env::var("XTENSA_GCC").unwrap().as_str(),
-            );
-        }
-        if std::env::var("RISCV_GCC").is_ok() {
-            env_file =
-                env_file.replace("{riscv_gcc}", std::env::var("RISCV_GCC").unwrap().as_str());
-        }
-        if std::env::var("LIBCLANG_PATH").is_ok() {
-            env_file = env_file.replace(
-                "{libclang_path}",
-                std::env::var("LIBCLANG_PATH").unwrap().as_str(),
-            );
-        }
+
+        let xtensa_gcc = std::env::var("XTENSA_GCC").unwrap_or_default();
+        env_file = env_file.replace("{xtensa_gcc}", &xtensa_gcc);
+
+        let riscv_gcc = std::env::var("RISCV_GCC").unwrap_or_default();
+        env_file = env_file.replace("{riscv_gcc}", &riscv_gcc);
+
+        let libclang_path = std::env::var("LIBCLANG_PATH").unwrap_or_default();
+        env_file = env_file.replace("{libclang_path}", &libclang_path);
+
         write_file(&env_file_path, &env_file)?;
         Ok(())
     }

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -301,10 +301,12 @@ impl UnixShell for Fish {
     }
 }
 
+#[cfg(unix)]
 pub(crate) fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
     cmds.iter().cloned().find(|&s| has_cmd(s))
 }
 
+#[cfg(unix)]
 fn has_cmd(cmd: &str) -> bool {
     let cmd = format!("{}{}", cmd, env::consts::EXE_SUFFIX);
     let path = env::var("PATH").unwrap_or_default();

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -92,11 +92,11 @@ pub(crate) trait UnixShell {
     fn update_rcs(&self) -> Vec<PathBuf>;
 
     // Writes the relevant env file.
-    fn env_script(&self, toolchain_dir: &PathBuf) -> ShellScript {
+    fn env_script(&self, toolchain_dir: &Path) -> ShellScript {
         ShellScript {
             name: "env",
             content: include_str!("env.sh"),
-            toolchain_dir: toolchain_dir.clone(),
+            toolchain_dir: toolchain_dir.to_path_buf(),
         }
     }
 
@@ -234,11 +234,11 @@ impl UnixShell for Fish {
         self.rcfiles()
     }
 
-    fn env_script(&self, toolchain_dir: &PathBuf) -> ShellScript {
+    fn env_script(&self, toolchain_dir: &Path) -> ShellScript {
         ShellScript {
             name: "env.fish",
             content: include_str!("env.fish"),
-            toolchain_dir: toolchain_dir.clone(),
+            toolchain_dir: toolchain_dir.to_path_buf(),
         }
     }
 

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -75,8 +75,8 @@ impl ShellScript {
     }
 }
 
-// Cross-platform non-POSIX shells have not been assessed for integration yet
 #[cfg(unix)]
+/// Cross-platform non-POSIX shells have not been assessed for integration yet
 fn enumerate_shells() -> Vec<Shell> {
     vec![
         Box::new(Posix),
@@ -87,16 +87,17 @@ fn enumerate_shells() -> Vec<Shell> {
 }
 
 #[cfg(unix)]
+/// Returns all shells that exist on the system.
 pub(super) fn get_available_shells() -> impl Iterator<Item = Shell> {
     enumerate_shells().into_iter().filter(|sh| sh.does_exist())
 }
 
 #[cfg(windows)]
 pub trait WindowsShell {
-    // Writes the relevant env file.
+    /// Writes the relevant env file.
     fn env_script(&self, toolchain_dir: &Path) -> ShellScript;
 
-    // Gives the source string for a given shell.
+    /// Gives the source string for a given shell.
     fn source_string(&self, toolchain_dir: &str) -> Result<String, Error>;
 }
 
@@ -136,18 +137,18 @@ impl WindowsShell for Powershell {
 
 #[cfg(unix)]
 pub trait UnixShell {
-    // Detects if a shell "exists". Users have multiple shells, so an "eager"
-    // heuristic should be used, assuming shells exist if any traces do.
+    /// Detects if a shell "exists". Users have multiple shells, so an "eager"
+    /// heuristic should be used, assuming shells exist if any traces do.
     fn does_exist(&self) -> bool;
 
-    // Gives all rcfiles of a given shell that Rustup is concerned with.
-    // Used primarily in checking rcfiles for cleanup.
+    /// Gives all rcfiles of a given shell that Rustup is concerned with.
+    /// Used primarily in checking rcfiles for cleanup.
     fn rcfiles(&self) -> Vec<PathBuf>;
 
-    // Gives rcs that should be written to.
+    /// Gives rcs that should be written to.
     fn update_rcs(&self) -> Vec<PathBuf>;
 
-    // Writes the relevant env file.
+    /// Writes the relevant env file.
     fn env_script(&self, toolchain_dir: &Path) -> ShellScript {
         ShellScript {
             name: "env",
@@ -156,7 +157,7 @@ pub trait UnixShell {
         }
     }
 
-    // Gives the source string for a given shell.
+    /// Gives the source string for a given shell.
     fn source_string(&self, toolchain_dir: &str) -> Result<String, Error> {
         Ok(format!(r#". "{}/env""#, toolchain_dir))
     }
@@ -303,11 +304,13 @@ impl UnixShell for Fish {
 }
 
 #[cfg(unix)]
+/// Finds the command for a given string.
 pub(crate) fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
     cmds.iter().cloned().find(|&s| has_cmd(s))
 }
 
 #[cfg(unix)]
+/// Checks if a command exists in the PATH.
 fn has_cmd(cmd: &str) -> bool {
     let cmd = format!("{}{}", cmd, env::consts::EXE_SUFFIX);
     let path = env::var("PATH").unwrap_or_default();
@@ -316,6 +319,7 @@ fn has_cmd(cmd: &str) -> bool {
         .any(|p| p.exists())
 }
 
+/// Writes a file to a given path.
 pub fn write_file(path: &Path, contents: &str) -> Result<(), Error> {
     let mut file = OpenOptions::new()
         .write(true)

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -290,7 +290,7 @@ pub(crate) fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
 
 fn has_cmd(cmd: &str) -> bool {
     let cmd = format!("{}{}", cmd, env::consts::EXE_SUFFIX);
-    let path = std::env::var_os("PATH").unwrap_or_default();
+    let path = std::env::var("PATH").unwrap_or_default();
     env::split_paths(&path)
         .map(|p| p.join(&cmd))
         .any(|p| p.exists())

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -100,8 +100,8 @@ pub(crate) trait UnixShell {
         }
     }
 
-    fn source_string(&self) -> Result<String> {
-        Ok(format!(r#". "{}/env""#, "get_export_file()?"))
+    fn source_string(&self, toolchain_dir: &str) -> Result<String> {
+        Ok(format!(r#". "{}/env""#, toolchain_dir))
     }
 }
 
@@ -242,21 +242,9 @@ impl UnixShell for Fish {
         }
     }
 
-    fn source_string(&self) -> Result<String> {
-        Ok(format!(r#". "{}/env.fish""#, "get_export_file()?"))
+    fn source_string(&self, toolchain_dir: &str) -> Result<String> {
+        Ok(format!(r#". "{}/env.fish""#, toolchain_dir))
     }
-}
-
-pub(crate) fn legacy_paths() -> impl Iterator<Item = PathBuf> {
-    // TODO: Avoid using BaseDirs::new... so many times, also in other places.
-    let zprofiles = Zsh::zdotdir()
-        .into_iter()
-        .chain(Some(BaseDirs::new().unwrap().home_dir().into()))
-        .map(|d| d.join(".zprofile"));
-    let profiles = [".bash_profile", ".profile"]
-        .iter()
-        .map(|rc| BaseDirs::new().unwrap().home_dir().join(rc));
-    profiles.chain(zprofiles)
 }
 
 pub(crate) fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
@@ -284,11 +272,3 @@ pub fn write_file(path: &Path, contents: &str) -> Result<()> {
 
     Ok(())
 }
-
-// /// Obtain the current instance of HomeProcess
-// pub(crate) fn home_process() -> Process {
-//     match PROCESS.with(|p| p.borrow().clone()) {
-//         None => panic!("No process instance"),
-//         Some(p) => p,
-//     }
-// }

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -34,10 +34,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub(crate) type Shell = Box<dyn UnixShell>;
+pub(super) type Shell = Box<dyn UnixShell>;
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct ShellScript {
+pub struct ShellScript {
     content: &'static str,
     name: &'static str,
     toolchain_dir: PathBuf,
@@ -80,11 +80,11 @@ fn enumerate_shells() -> Vec<Shell> {
     ]
 }
 
-pub(crate) fn get_available_shells() -> impl Iterator<Item = Shell> {
+pub(super) fn get_available_shells() -> impl Iterator<Item = Shell> {
     enumerate_shells().into_iter().filter(|sh| sh.does_exist())
 }
 
-pub(crate) trait WindowsShell {
+pub trait WindowsShell {
     // Writes the relevant env file.
     fn env_script(&self, toolchain_dir: &Path) -> ShellScript;
 
@@ -123,7 +123,7 @@ impl WindowsShell for Powershell {
     }
 }
 
-pub(crate) trait UnixShell {
+pub trait UnixShell {
     // Detects if a shell "exists". Users have multiple shells, so an "eager"
     // heuristic should be used, assuming shells exist if any traces do.
     fn does_exist(&self) -> bool;
@@ -192,7 +192,6 @@ impl UnixShell for Bash {
 }
 
 struct Zsh;
-
 impl Zsh {
     fn zdotdir() -> Result<PathBuf, Error> {
         use std::ffi::OsStr;
@@ -247,7 +246,6 @@ impl UnixShell for Zsh {
 }
 
 struct Fish;
-
 impl UnixShell for Fish {
     fn does_exist(&self) -> bool {
         // fish has to either be the shell or be callable for fish setup.

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -25,8 +25,7 @@
 //! 1) using a shell script that updates PATH if the path is not in PATH
 //! 2) sourcing this script (`. /path/to/script`) in any appropriate rc file
 
-use crate::error::Error;
-use directories::BaseDirs;
+use crate::{env::get_home_dir, error::Error};
 use miette::Result;
 use std::{
     env,
@@ -110,7 +109,7 @@ impl UnixShell for Posix {
     }
 
     fn rcfiles(&self) -> Vec<PathBuf> {
-        vec![BaseDirs::new().unwrap().home_dir().join(".profile")]
+        vec![get_home_dir().join(".profile")]
     }
 
     fn update_rcs(&self) -> Vec<PathBuf> {
@@ -132,7 +131,7 @@ impl UnixShell for Bash {
         // .profile as part of POSIX and always does setup for POSIX shells.
         [".bash_profile", ".bash_login", ".bashrc"]
             .iter()
-            .map(|rc| BaseDirs::new().unwrap().home_dir().join(rc))
+            .map(|rc| get_home_dir().join(rc))
             .collect()
     }
 
@@ -176,7 +175,7 @@ impl UnixShell for Zsh {
     }
 
     fn rcfiles(&self) -> Vec<PathBuf> {
-        let home_dir: Option<PathBuf> = Some(BaseDirs::new().unwrap().home_dir().into());
+        let home_dir: Option<PathBuf> = Some(get_home_dir());
         [Zsh::zdotdir().ok(), home_dir]
             .iter()
             .filter_map(|dir| dir.as_ref().map(|p| p.join(".zshenv")))
@@ -217,10 +216,7 @@ impl UnixShell for Fish {
             path
         });
 
-        let p1 = BaseDirs::new()
-            .unwrap()
-            .home_dir()
-            .join(".config/fish/conf.d/espup.fish");
+        let p1 = get_home_dir().join(".config/fish/conf.d/espup.fish");
 
         p0.into_iter().chain(Some(p1)).collect()
     }

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -28,10 +28,12 @@
 use crate::error::Error;
 use directories::BaseDirs;
 use miette::Result;
-use std::env;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    fs::OpenOptions,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 pub(crate) type Shell = Box<dyn UnixShell>;
 

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -1,0 +1,293 @@
+// THIS FILE IS BASED ON RUSTUP SOURCE CODE: https://github.com/rust-lang/rustup/blob/b900a6cd87e1f463a55ce02e956c24b2cccdd0f0/src/cli/self_update/shell.rs
+
+//! Paths and Unix shells
+//!
+//! MacOS, Linux, FreeBSD, and many other OS model their design on Unix,
+//! so handling them is relatively consistent. But only relatively.
+//! POSIX postdates Unix by 20 years, and each "Unix-like" shell develops
+//! unique quirks over time.
+//!
+//!
+//! Windowing Managers, Desktop Environments, GUI Terminals, and PATHs
+//!
+//! Duplicating paths in PATH can cause performance issues when the OS searches
+//! the same place multiple times. Traditionally, Unix configurations have
+//! resolved this by setting up PATHs in the shell's login profile.
+//!
+//! This has its own issues. Login profiles are only intended to run once, but
+//! changing the PATH is common enough that people may run it twice. Desktop
+//! environments often choose to NOT start login shells in GUI terminals. Thus,
+//! a trend has emerged to place PATH updates in other run-commands (rc) files,
+//! leaving Rustup with few assumptions to build on for fulfilling its promise
+//! to set up PATH appropriately.
+//!
+//! Rustup addresses this by:
+//! 1) using a shell script that updates PATH if the path is not in PATH
+//! 2) sourcing this script (`. /path/to/script`) in any appropriate rc file
+
+use crate::error::Error;
+use directories::BaseDirs;
+use log::{error, warn};
+use std::borrow::Cow;
+use std::env;
+use std::fs::OpenOptions;
+use std::io::{Result, Write};
+
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+
+// use super::get_export_file;
+
+// thread_local! {
+//     pub(crate) static PROCESS:RefCell<Option<Process>> = RefCell::new(None);
+// }
+
+// use super::utils;
+// use crate::{currentprocess::varsource::VarSource, process};
+
+pub(crate) type Shell = Box<dyn UnixShell>;
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct ShellScript {
+    content: &'static str,
+    name: &'static str,
+}
+
+impl ShellScript {
+    pub(crate) fn write(&self) -> Result<()> {
+        // // Export file name
+        // let env_name = toolch.join(self.name);
+        // // Export file content
+        // let env_file = self.content;
+        // write_file(self.name, &env_name, &env_file)?;
+        Ok(())
+    }
+}
+
+// TODO: Tcsh (BSD)
+// TODO?: Make a decision on Ion Shell, Power Shell, Nushell
+// Cross-platform non-POSIX shells have not been assessed for integration yet
+fn enumerate_shells() -> Vec<Shell> {
+    vec![
+        Box::new(Posix),
+        Box::new(Bash),
+        Box::new(Zsh),
+        Box::new(Fish),
+    ]
+}
+
+pub(crate) fn get_available_shells() -> impl Iterator<Item = Shell> {
+    enumerate_shells().into_iter().filter(|sh| sh.does_exist())
+}
+
+pub(crate) trait UnixShell {
+    // Detects if a shell "exists". Users have multiple shells, so an "eager"
+    // heuristic should be used, assuming shells exist if any traces do.
+    fn does_exist(&self) -> bool;
+
+    // Gives all rcfiles of a given shell that Rustup is concerned with.
+    // Used primarily in checking rcfiles for cleanup.
+    fn rcfiles(&self) -> Vec<PathBuf>;
+
+    // Gives rcs that should be written to.
+    fn update_rcs(&self) -> Vec<PathBuf>;
+
+    // Writes the relevant env file.
+    fn env_script(&self) -> ShellScript {
+        ShellScript {
+            name: "env",
+            content: include_str!("env.sh"),
+        }
+    }
+
+    fn source_string(&self) -> Result<String> {
+        Ok(format!(r#". "{}/env""#, "get_export_file()?"))
+    }
+}
+
+struct Posix;
+impl UnixShell for Posix {
+    fn does_exist(&self) -> bool {
+        true
+    }
+
+    fn rcfiles(&self) -> Vec<PathBuf> {
+        vec![BaseDirs::new().unwrap().home_dir().join(".profile")]
+    }
+
+    fn update_rcs(&self) -> Vec<PathBuf> {
+        // Write to .profile even if it doesn't exist. It's the only rc in the
+        // POSIX spec so it should always be set up.
+        self.rcfiles()
+    }
+}
+
+struct Bash;
+
+impl UnixShell for Bash {
+    fn does_exist(&self) -> bool {
+        !self.update_rcs().is_empty()
+    }
+
+    fn rcfiles(&self) -> Vec<PathBuf> {
+        // Bash also may read .profile, however Rustup already includes handling
+        // .profile as part of POSIX and always does setup for POSIX shells.
+        [".bash_profile", ".bash_login", ".bashrc"]
+            .iter()
+            .map(|rc| BaseDirs::new().unwrap().home_dir().join(rc))
+            .collect()
+        // TODO: Verify the output of this
+    }
+
+    fn update_rcs(&self) -> Vec<PathBuf> {
+        self.rcfiles()
+            .into_iter()
+            .filter(|rc| rc.is_file())
+            .collect()
+    }
+}
+
+struct Zsh;
+
+impl Zsh {
+    fn zdotdir() -> Result<PathBuf> {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        if matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("zsh")) {
+            match std::env::var("ZDOTDIR") {
+                Ok(dir) if !dir.is_empty() => Ok(PathBuf::from(dir)),
+                _ => panic!("ZDOTDIR not set"),
+                // TODO:IMPROVE
+            }
+        } else {
+            match std::process::Command::new("zsh")
+                .args(["-c", "'echo $ZDOTDIR'"])
+                .output()
+            {
+                Ok(io) if !io.stdout.is_empty() => Ok(PathBuf::from(OsStr::from_bytes(&io.stdout))),
+                _ => panic!("ZDOTDIR not set"),
+                // TODO:IMPROVE
+            }
+        }
+    }
+}
+
+impl UnixShell for Zsh {
+    fn does_exist(&self) -> bool {
+        // zsh has to either be the shell or be callable for zsh setup.
+        matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("zsh"))
+            || find_cmd(&["zsh"]).is_some()
+    }
+
+    fn rcfiles(&self) -> Vec<PathBuf> {
+        let home_dir: Option<PathBuf> = Some(BaseDirs::new().unwrap().home_dir().into());
+        [Zsh::zdotdir().ok(), home_dir]
+            .iter()
+            .filter_map(|dir| dir.as_ref().map(|p| p.join(".zshenv")))
+            .collect()
+    }
+
+    fn update_rcs(&self) -> Vec<PathBuf> {
+        // zsh can change $ZDOTDIR both _before_ AND _during_ reading .zshenv,
+        // so we: write to $ZDOTDIR/.zshenv if-exists ($ZDOTDIR changes before)
+        // OR write to $HOME/.zshenv if it exists (change-during)
+        // if neither exist, we create it ourselves, but using the same logic,
+        // because we must still respond to whether $ZDOTDIR is set or unset.
+        // In any case we only write once.
+        self.rcfiles()
+            .into_iter()
+            .filter(|env| env.is_file())
+            .chain(self.rcfiles())
+            .take(1)
+            .collect()
+    }
+}
+
+struct Fish;
+
+impl UnixShell for Fish {
+    fn does_exist(&self) -> bool {
+        // fish has to either be the shell or be callable for fish setup.
+        matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("fish"))
+            || find_cmd(&["fish"]).is_some()
+    }
+
+    // > "$XDG_CONFIG_HOME/fish/conf.d" (or "~/.config/fish/conf.d" if that variable is unset) for the user
+    // from <https://github.com/fish-shell/fish-shell/issues/3170#issuecomment-228311857>
+    fn rcfiles(&self) -> Vec<PathBuf> {
+        let p0 = std::env::var("XDG_CONFIG_HOME").ok().map(|p| {
+            let mut path = PathBuf::from(p);
+            path.push("fish/conf.d/espup.fish");
+            path
+        });
+
+        let p1 = BaseDirs::new()
+            .unwrap()
+            .home_dir()
+            .join(".config/fish/conf.d/espup.fish");
+
+        p0.into_iter().chain(Some(p1)).collect()
+    }
+
+    fn update_rcs(&self) -> Vec<PathBuf> {
+        self.rcfiles()
+    }
+
+    fn env_script(&self) -> ShellScript {
+        ShellScript {
+            name: "env.fish",
+            content: include_str!("env.fish"),
+        }
+    }
+
+    fn source_string(&self) -> Result<String> {
+        Ok(format!(r#". "{}/env.fish""#, "get_export_file()?"))
+    }
+}
+
+pub(crate) fn legacy_paths() -> impl Iterator<Item = PathBuf> {
+    // TODO: Avoid using BaseDirs::new... so many times, also in other places.
+    let zprofiles = Zsh::zdotdir()
+        .into_iter()
+        .chain(Some(BaseDirs::new().unwrap().home_dir().into()))
+        .map(|d| d.join(".zprofile"));
+    let profiles = [".bash_profile", ".profile"]
+        .iter()
+        .map(|rc| BaseDirs::new().unwrap().home_dir().join(rc));
+    profiles.chain(zprofiles)
+}
+
+pub(crate) fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
+    cmds.iter().cloned().find(|&s| has_cmd(s))
+}
+
+fn has_cmd(cmd: &str) -> bool {
+    let cmd = format!("{}{}", cmd, env::consts::EXE_SUFFIX);
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    env::split_paths(&path)
+        .map(|p| p.join(&cmd))
+        .any(|p| p.exists())
+}
+
+pub fn write_file(path: &Path, contents: &str) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(path)?;
+
+    Write::write_all(&mut file, contents.as_bytes())?;
+
+    file.sync_data()?;
+
+    Ok(())
+}
+
+// /// Obtain the current instance of HomeProcess
+// pub(crate) fn home_process() -> Process {
+//     match PROCESS.with(|p| p.borrow().clone()) {
+//         None => panic!("No process instance"),
+//         Some(p) => p,
+//     }
+// }

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -45,8 +45,6 @@ pub(crate) struct ShellScript {
 
 impl ShellScript {
     pub(crate) fn write(&self) -> Result<(), Error> {
-        // TODO: SOMETHING SIMILAR FOR WINDOWS
-        // TODO: IN WINDOWS, REPLACE SLASHS FOR BACKSLASH
         let env_file_path = self.toolchain_dir.join(self.name);
         let mut env_file: String = self.content.to_string();
 

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -34,7 +34,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(unix)]
 pub(super) type Shell = Box<dyn UnixShell>;
+#[cfg(windows)]
+pub(super) type Shell = Box<dyn WindowsShellShell>;
 
 #[derive(Debug, PartialEq)]
 pub struct ShellScript {

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -25,25 +25,11 @@
 //! 1) using a shell script that updates PATH if the path is not in PATH
 //! 2) sourcing this script (`. /path/to/script`) in any appropriate rc file
 
-use crate::error::Error;
 use directories::BaseDirs;
-use log::{error, warn};
-use std::borrow::Cow;
 use std::env;
 use std::fs::OpenOptions;
 use std::io::{Result, Write};
-
-use std::cell::RefCell;
 use std::path::{Path, PathBuf};
-
-// use super::get_export_file;
-
-// thread_local! {
-//     pub(crate) static PROCESS:RefCell<Option<Process>> = RefCell::new(None);
-// }
-
-// use super::utils;
-// use crate::{currentprocess::varsource::VarSource, process};
 
 pub(crate) type Shell = Box<dyn UnixShell>;
 
@@ -58,7 +44,9 @@ impl ShellScript {
         // // Export file name
         // let env_name = toolch.join(self.name);
         // // Export file content
-        // let env_file = self.content;
+        // REPLACE PLACEHOLDERS WITH ENVIRONMENT CVAIRABLES VALUES
+        // let env_file = self.content.replace(std::);
+
         // write_file(self.name, &env_name, &env_file)?;
         Ok(())
     }

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -114,7 +114,6 @@ impl WindowsShell for Batch {
 
     fn source_string(&self, toolchain_dir: &str) -> Result<String, Error> {
         Ok(format!(r#"{}/env.bat""#, toolchain_dir))
-        // TODO: VERIFY THE SOURCE COMMAND
     }
 }
 

--- a/src/env/shell.rs
+++ b/src/env/shell.rs
@@ -51,21 +51,21 @@ impl ShellScript {
         let env_file_path = self.toolchain_dir.join(self.name);
         let mut env_file: String = self.content.to_string();
 
-        let xtensa_gcc = std::env::var("XTENSA_GCC").unwrap_or_default();
+        let xtensa_gcc = env::var("XTENSA_GCC").unwrap_or_default();
         env_file = env_file.replace("{xtensa_gcc}", &xtensa_gcc);
 
-        let riscv_gcc = std::env::var("RISCV_GCC").unwrap_or_default();
+        let riscv_gcc = env::var("RISCV_GCC").unwrap_or_default();
         env_file = env_file.replace("{riscv_gcc}", &riscv_gcc);
 
-        let libclang_path = std::env::var("LIBCLANG_PATH").unwrap_or_default();
+        let libclang_path = env::var("LIBCLANG_PATH").unwrap_or_default();
         env_file = env_file.replace("{libclang_path}", &libclang_path);
         #[cfg(windows)]
         if cfg!(windows) {
-            let libclang_bin_path = std::env::var("LIBCLANG_BIN_PATH").unwrap_or_default();
+            let libclang_bin_path = env::var("LIBCLANG_BIN_PATH").unwrap_or_default();
             env_file = env_file.replace("{libclang_bin_path}", &libclang_bin_path);
         }
 
-        let clang_path = std::env::var("CLANG_PATH").unwrap_or_default();
+        let clang_path = env::var("CLANG_PATH").unwrap_or_default();
         env_file = env_file.replace("{clang_path}", &clang_path);
 
         write_file(&env_file_path, &env_file)?;
@@ -200,8 +200,8 @@ impl Zsh {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
-        if matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("zsh")) {
-            match std::env::var("ZDOTDIR") {
+        if matches!(env::var("SHELL"), Ok(sh) if sh.contains("zsh")) {
+            match env::var("ZDOTDIR") {
                 Ok(dir) if !dir.is_empty() => Ok(PathBuf::from(dir)),
                 _ => Err(Error::Zdotdir),
             }
@@ -220,8 +220,7 @@ impl Zsh {
 impl UnixShell for Zsh {
     fn does_exist(&self) -> bool {
         // zsh has to either be the shell or be callable for zsh setup.
-        matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("zsh"))
-            || find_cmd(&["zsh"]).is_some()
+        matches!(env::var("SHELL"), Ok(sh) if sh.contains("zsh")) || find_cmd(&["zsh"]).is_some()
     }
 
     fn rcfiles(&self) -> Vec<PathBuf> {
@@ -252,14 +251,13 @@ struct Fish;
 impl UnixShell for Fish {
     fn does_exist(&self) -> bool {
         // fish has to either be the shell or be callable for fish setup.
-        matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("fish"))
-            || find_cmd(&["fish"]).is_some()
+        matches!(env::var("SHELL"), Ok(sh) if sh.contains("fish")) || find_cmd(&["fish"]).is_some()
     }
 
     // > "$XDG_CONFIG_HOME/fish/conf.d" (or "~/.config/fish/conf.d" if that variable is unset) for the user
     // from <https://github.com/fish-shell/fish-shell/issues/3170#issuecomment-228311857>
     fn rcfiles(&self) -> Vec<PathBuf> {
-        let p0 = std::env::var("XDG_CONFIG_HOME").ok().map(|p| {
+        let p0 = env::var("XDG_CONFIG_HOME").ok().map(|p| {
             let mut path = PathBuf::from(p);
             path.push("fish/conf.d/espup.fish");
             path
@@ -293,7 +291,7 @@ pub(crate) fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
 
 fn has_cmd(cmd: &str) -> bool {
     let cmd = format!("{}{}", cmd, env::consts::EXE_SUFFIX);
-    let path = std::env::var("PATH").unwrap_or_default();
+    let path = env::var("PATH").unwrap_or_default();
     env::split_paths(&path)
         .map(|p| p.join(&cmd))
         .any(|p| p.exists())

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -79,6 +79,8 @@ pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
 
     remove_legacy_export_file()?;
 
+    print_post_install_msg(&toolchain_dir.display().to_string());
+
     Ok(())
 }
 
@@ -104,4 +106,13 @@ fn remove_legacy_export_file() -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+fn print_post_install_msg(toolchain_dir: &str) {
+    println!("\tTo get started you may need to restart your current shell.");
+    println!("\tTo configure your current shell, run:");
+    println!(
+        "\t'. {}/env' or '. {}/env.fish' depending on your shell",
+        toolchain_dir, toolchain_dir
+    );
 }

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -1,0 +1,68 @@
+use crate::error::Error;
+use std::fs::OpenOptions;
+
+// // TODO: USED FOR UNINSTALING
+// pub(crate) fn do_remove_from_path() -> Result<()> {
+//     for sh in shell::get_available_shells() {
+//         let source_bytes = format!("{}\n", sh.source_string()?).into_bytes();
+
+//         // Check more files for cleanup than normally are updated.
+//         for rc in sh.rcfiles().iter().filter(|rc| rc.is_file()) {
+//             let file = utils::read_file("rcfile", rc)?;
+//             let file_bytes = file.into_bytes();
+//             // FIXME: This is whitespace sensitive where it should not be.
+//             if let Some(idx) = file_bytes
+//                 .windows(source_bytes.len())
+//                 .position(|w| w == source_bytes.as_slice())
+//             {
+//                 // Here we rewrite the file without the offending line.
+//                 let mut new_bytes = file_bytes[..idx].to_vec();
+//                 new_bytes.extend(&file_bytes[idx + source_bytes.len()..]);
+//                 let new_file = String::from_utf8(new_bytes).unwrap();
+//                 utils::write_file("rcfile", rc, &new_file)?;
+//             }
+//         }
+//     }
+
+//     remove_legacy_paths()?;
+
+//     Ok(())
+// }
+
+// pub(crate) fn do_add_to_path() -> Result<()> {
+//     for sh in shell::get_available_shells() {
+//         let source_cmd = sh.source_string()?;
+//         let source_cmd_with_newline = format!("\n{}", &source_cmd);
+
+//         for rc in sh.update_rcs() {
+//             let cmd_to_write = match utils::read_file("rcfile", &rc) {
+//                 Ok(contents) if contents.contains(&source_cmd) => continue,
+//                 Ok(contents) if !contents.ends_with('\n') => &source_cmd_with_newline,
+//                 _ => &source_cmd,
+//             };
+
+//             utils::append_file("rcfile", &rc, cmd_to_write)
+//                 .with_context(|| format!("could not amend shell profile: '{}'", rc.display()))?;
+//         }
+//     }
+
+//     remove_legacy_paths()?;
+
+//     Ok(())
+// }
+
+// // TODO: THIS IS CALLED BEFORE do_add_to_path()
+// pub(crate) fn do_write_env_files() -> Result<()> {
+//     let mut written = vec![];
+
+//     for sh in shell::get_available_shells() {
+//         let script = sh.env_script();
+//         // Only write each possible script once.
+//         if !written.contains(&script) {
+//             script.write()?;
+//             written.push(script);
+//         }
+//     }
+
+//     Ok(())
+// }

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -79,8 +79,6 @@ pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
 
     remove_legacy_export_file()?;
 
-    print_post_install_msg(&toolchain_dir.display().to_string());
-
     Ok(())
 }
 
@@ -106,13 +104,4 @@ fn remove_legacy_export_file() -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-fn print_post_install_msg(toolchain_dir: &str) {
-    println!("\tTo get started you may need to restart your current shell.");
-    println!("\tTo configure your current shell, run:");
-    println!(
-        "\t'. {}/env' or '. {}/env.fish' depending on your shell",
-        toolchain_dir, toolchain_dir
-    );
 }

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -1,3 +1,5 @@
+//! Unix specific environment functions.
+
 use crate::{env::get_home_dir, env::shell, error::Error};
 use miette::Result;
 use std::{
@@ -8,7 +10,7 @@ use std::{
 
 const LEGACY_EXPORT_FILE: &str = "export-esp.sh";
 
-// Clean the environment for Windows.
+/// Clean the environment for Windows.
 pub(super) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_bytes = format!(
@@ -50,7 +52,7 @@ pub(super) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-// Delete the legacy export file.
+/// Delete the legacy export file.
 fn remove_legacy_export_file() -> Result<(), Error> {
     let legacy_file = get_home_dir().join(LEGACY_EXPORT_FILE);
     if legacy_file.exists() {
@@ -60,7 +62,7 @@ fn remove_legacy_export_file() -> Result<(), Error> {
     Ok(())
 }
 
-// Update the environment for Unix.
+/// Update the environment for Unix.
 pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_cmd = sh.source_string(&toolchain_dir.display().to_string())?;
@@ -94,7 +96,7 @@ pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-// Write the environment files for Unix.
+/// Write the environment files for Unix.
 pub(super) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
     let mut written = vec![];
 

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -1,10 +1,12 @@
-use crate::{env::shell, error::Error};
+use crate::{env::get_home_dir, env::shell, error::Error};
 use miette::Result;
 use std::{
-    fs::OpenOptions,
+    fs::{remove_file, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
 };
+
+const LEGACY_EXPORT_FILE: &str = "export-esp.sh";
 
 pub fn do_remove_from_path(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
@@ -42,6 +44,8 @@ pub fn do_remove_from_path(toolchain_dir: &Path) -> Result<(), Error> {
         }
     }
 
+    remove_legacy_export_file()?;
+
     Ok(())
 }
 
@@ -73,6 +77,8 @@ pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
         }
     }
 
+    remove_legacy_export_file()?;
+
     Ok(())
 }
 
@@ -86,6 +92,15 @@ pub(crate) fn do_write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
             script.write()?;
             written.push(script);
         }
+    }
+
+    Ok(())
+}
+
+fn remove_legacy_export_file() -> Result<(), Error> {
+    let legacy_file = get_home_dir().join(LEGACY_EXPORT_FILE);
+    if legacy_file.exists() {
+        remove_file(&legacy_file)?;
     }
 
     Ok(())

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -1,59 +1,80 @@
 use crate::env::shell;
 use crate::error::Error;
 use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::PathBuf;
 
 // // TODO: USED FOR UNINSTALING
-// pub(crate) fn do_remove_from_path() -> Result<()> {
-//     for sh in shell::get_available_shells() {
-//         let source_bytes = format!("{}\n", sh.source_string()?).into_bytes();
+pub fn do_remove_from_path(toolchain_dir: &PathBuf) -> Result<(), Error> {
+    for sh in shell::get_available_shells() {
+        let source_bytes = format!(
+            "{}\n",
+            sh.source_string(&toolchain_dir.display().to_string())?
+        )
+        .into_bytes();
 
-//         // Check more files for cleanup than normally are updated.
-//         for rc in sh.rcfiles().iter().filter(|rc| rc.is_file()) {
-//             let file = utils::read_file("rcfile", rc)?;
-//             let file_bytes = file.into_bytes();
-//             // FIXME: This is whitespace sensitive where it should not be.
-//             if let Some(idx) = file_bytes
-//                 .windows(source_bytes.len())
-//                 .position(|w| w == source_bytes.as_slice())
-//             {
-//                 // Here we rewrite the file without the offending line.
-//                 let mut new_bytes = file_bytes[..idx].to_vec();
-//                 new_bytes.extend(&file_bytes[idx + source_bytes.len()..]);
-//                 let new_file = String::from_utf8(new_bytes).unwrap();
-//                 utils::write_file("rcfile", rc, &new_file)?;
-//             }
-//         }
-//     }
+        // Check more files for cleanup than normally are updated.
+        for rc in sh.rcfiles().iter().filter(|rc| rc.is_file()) {
+            let file = std::fs::read_to_string(&rc).map_err(|_| Error::ReadingFile {
+                name: "rcfile",
+                path: PathBuf::from(&rc),
+            })?;
+            let file_bytes = file.into_bytes();
+            // FIXME: This is whitespace sensitive where it should not be.
+            if let Some(idx) = file_bytes
+                .windows(source_bytes.len())
+                .position(|w| w == source_bytes.as_slice())
+            {
+                // Here we rewrite the file without the offending line.
+                let mut new_bytes = file_bytes[..idx].to_vec();
+                new_bytes.extend(&file_bytes[idx + source_bytes.len()..]);
+                let new_file = String::from_utf8(new_bytes).unwrap();
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .create(true)
+                    .open(rc)?;
+                Write::write_all(&mut file, new_file.as_bytes())?;
 
-//     remove_legacy_paths()?;
+                file.sync_data()?;
+            }
+        }
+    }
 
-//     Ok(())
-// }
+    Ok(())
+}
 
-// pub(crate) fn do_add_to_path() -> Result<()> {
-//     for sh in shell::get_available_shells() {
-//         let source_cmd = sh.source_string()?;
-//         let source_cmd_with_newline = format!("\n{}", &source_cmd);
+pub(crate) fn do_add_to_path(toolchain_dir: &PathBuf) -> Result<(), Error> {
+    for sh in shell::get_available_shells() {
+        let source_cmd = sh.source_string(&toolchain_dir.display().to_string())?;
+        let source_cmd_with_newline = format!("\n{}", &source_cmd);
 
-//         for rc in sh.update_rcs() {
-//             let cmd_to_write = match utils::read_file("rcfile", &rc) {
-//                 Ok(contents) if contents.contains(&source_cmd) => continue,
-//                 Ok(contents) if !contents.ends_with('\n') => &source_cmd_with_newline,
-//                 _ => &source_cmd,
-//             };
+        for rc in sh.update_rcs() {
+            let file = std::fs::read_to_string(&rc).map_err(|_| Error::ReadingFile {
+                name: "rcfile",
+                path: PathBuf::from(&rc),
+            });
+            let cmd_to_write: &str = match file {
+                Ok(contents) if contents.contains(&source_cmd) => continue,
+                Ok(contents) if !contents.ends_with('\n') => &source_cmd_with_newline,
+                _ => &source_cmd,
+            };
 
-//             utils::append_file("rcfile", &rc, cmd_to_write)
-//                 .with_context(|| format!("could not amend shell profile: '{}'", rc.display()))?;
-//         }
-//     }
+            let mut dest_file = OpenOptions::new()
+                .write(true)
+                .append(true)
+                .create(true)
+                .open(&rc)?;
 
-//     remove_legacy_paths()?;
+            writeln!(dest_file, "{cmd_to_write}")?;
 
-//     Ok(())
-// }
+            dest_file.sync_data()?;
+        }
+    }
 
-// // TODO: THIS IS CALLED BEFORE do_add_to_path()
+    Ok(())
+}
+
 pub(crate) fn do_write_env_files(toolchain_dir: &PathBuf) -> Result<(), Error> {
     let mut written = vec![];
 

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -8,7 +8,7 @@ use std::{
 
 const LEGACY_EXPORT_FILE: &str = "export-esp.sh";
 
-pub fn do_remove_from_path(toolchain_dir: &Path) -> Result<(), Error> {
+pub fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_bytes = format!(
             "{}\n",

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -8,7 +8,8 @@ use std::{
 
 const LEGACY_EXPORT_FILE: &str = "export-esp.sh";
 
-pub fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
+// Clean the environment for Windows.
+pub(super) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_bytes = format!(
             "{}\n",
@@ -49,6 +50,17 @@ pub fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
+// Delete the legacy export file.
+fn remove_legacy_export_file() -> Result<(), Error> {
+    let legacy_file = get_home_dir().join(LEGACY_EXPORT_FILE);
+    if legacy_file.exists() {
+        remove_file(&legacy_file)?;
+    }
+
+    Ok(())
+}
+
+// Update the environment for Unix.
 pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_cmd = sh.source_string(&toolchain_dir.display().to_string())?;
@@ -82,7 +94,8 @@ pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
+// Write the environment files for Unix.
+pub(super) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
     let mut written = vec![];
 
     for sh in shell::get_available_shells() {
@@ -92,15 +105,6 @@ pub(crate) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
             script.write()?;
             written.push(script);
         }
-    }
-
-    Ok(())
-}
-
-fn remove_legacy_export_file() -> Result<(), Error> {
-    let legacy_file = get_home_dir().join(LEGACY_EXPORT_FILE);
-    if legacy_file.exists() {
-        remove_file(&legacy_file)?;
     }
 
     Ok(())

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -1,5 +1,6 @@
 use crate::env::shell;
 use crate::error::Error;
+use miette::Result;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -1,5 +1,7 @@
+use crate::env::shell;
 use crate::error::Error;
 use std::fs::OpenOptions;
+use std::path::PathBuf;
 
 // // TODO: USED FOR UNINSTALING
 // pub(crate) fn do_remove_from_path() -> Result<()> {
@@ -52,17 +54,17 @@ use std::fs::OpenOptions;
 // }
 
 // // TODO: THIS IS CALLED BEFORE do_add_to_path()
-// pub(crate) fn do_write_env_files() -> Result<()> {
-//     let mut written = vec![];
+pub(crate) fn do_write_env_files(toolchain_dir: &PathBuf) -> Result<(), Error> {
+    let mut written = vec![];
 
-//     for sh in shell::get_available_shells() {
-//         let script = sh.env_script();
-//         // Only write each possible script once.
-//         if !written.contains(&script) {
-//             script.write()?;
-//             written.push(script);
-//         }
-//     }
+    for sh in shell::get_available_shells() {
+        let script = sh.env_script(toolchain_dir);
+        // Only write each possible script once.
+        if !written.contains(&script) {
+            script.write()?;
+            written.push(script);
+        }
+    }
 
-//     Ok(())
-// }
+    Ok(())
+}

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -1,9 +1,10 @@
-use crate::env::shell;
-use crate::error::Error;
+use crate::{env::shell, error::Error};
 use miette::Result;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    fs::OpenOptions,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 pub fn do_remove_from_path(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -49,7 +49,7 @@ pub fn do_remove_from_path(toolchain_dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
+pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_cmd = sh.source_string(&toolchain_dir.display().to_string())?;
         let source_cmd_with_newline = format!("\n{}", &source_cmd);
@@ -82,7 +82,7 @@ pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn do_write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
+pub(crate) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
     let mut written = vec![];
 
     for sh in shell::get_available_shells() {

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -4,7 +4,6 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-// // TODO: USED FOR UNINSTALING
 pub fn do_remove_from_path(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_bytes = format!(

--- a/src/env/unix.rs
+++ b/src/env/unix.rs
@@ -2,10 +2,10 @@ use crate::env::shell;
 use crate::error::Error;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // // TODO: USED FOR UNINSTALING
-pub fn do_remove_from_path(toolchain_dir: &PathBuf) -> Result<(), Error> {
+pub fn do_remove_from_path(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_bytes = format!(
             "{}\n",
@@ -15,7 +15,7 @@ pub fn do_remove_from_path(toolchain_dir: &PathBuf) -> Result<(), Error> {
 
         // Check more files for cleanup than normally are updated.
         for rc in sh.rcfiles().iter().filter(|rc| rc.is_file()) {
-            let file = std::fs::read_to_string(&rc).map_err(|_| Error::ReadingFile {
+            let file = std::fs::read_to_string(rc).map_err(|_| Error::ReadingFile {
                 name: "rcfile",
                 path: PathBuf::from(&rc),
             })?;
@@ -44,7 +44,7 @@ pub fn do_remove_from_path(toolchain_dir: &PathBuf) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn do_add_to_path(toolchain_dir: &PathBuf) -> Result<(), Error> {
+pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
     for sh in shell::get_available_shells() {
         let source_cmd = sh.source_string(&toolchain_dir.display().to_string())?;
         let source_cmd_with_newline = format!("\n{}", &source_cmd);
@@ -75,7 +75,7 @@ pub(crate) fn do_add_to_path(toolchain_dir: &PathBuf) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn do_write_env_files(toolchain_dir: &PathBuf) -> Result<(), Error> {
+pub(crate) fn do_write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
     let mut written = vec![];
 
     for sh in shell::get_available_shells() {

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -5,6 +5,9 @@ use winreg::{
     RegKey,
 };
 
+const LEGACY_EXPORT_FILE: &str = "export-esp.ps1";
+
+// TODO: REVIEW CFGS
 #[cfg(windows)]
 /// Sets an environment variable for the current user.
 pub fn set_environment_variable(key: &str, value: &str) -> Result<(), Error> {
@@ -30,3 +33,48 @@ pub fn delete_environment_variable(key: &str) -> Result<(), Error> {
     environment_key.delete_value(key)?;
     Ok(())
 }
+
+pub(crate) fn do_write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
+    let windows_shells: Vec<shell::Shell> = vec![Box::new(Batch), Box::new(Powershell)];
+    for sh in windows_shells.into_iter() {
+        let script = sh.env_script(toolchain_dir);
+        script.write()?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    set_environment_variable("PATH", path)?;
+
+    let xtensa_gcc = std::env::var_os("XTENSA_GCC").unwrap_or_default();
+    set_environment_variable("XTENSA_GCC", xtensa_gcc)?;
+
+    let riscv_gcc = std::env::var_os("RISCV_GCC").unwrap_or_default();
+    set_environment_variable("RISCV_GCC", riscv_gcc)?;
+
+    let libclang_path = std::env::var_os("LIBCLANG_PATH");
+    if let Some(libclang_path) = libclang_path {
+        set_environment_variable("LIBCLANG_PATH", libclang_path)?;
+    }
+
+    let clang_path = std::env::var_os("CLANG_PATH");
+    if let Some(libclang_path) = clang_path {
+        set_environment_variable("CLANG_PATH", clang_path)?;
+    }
+
+    remove_legacy_export_file()?;
+
+    Ok(())
+}
+
+fn remove_legacy_export_file() -> Result<(), Error> {
+    let legacy_file = get_home_dir().join(LEGACY_EXPORT_FILE);
+    if legacy_file.exists() {
+        remove_file(&legacy_file)?;
+    }
+
+    Ok(())
+}
+// TODO: REMOVE LEGACY FILE

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -1,3 +1,5 @@
+//! Windows specific environment functions.
+
 use crate::{env::get_home_dir, env::shell, error::Error};
 use miette::Result;
 use std::{env, fs::remove_file, path::Path};
@@ -8,7 +10,7 @@ use winreg::{
 
 const LEGACY_EXPORT_FILE: &str = "export-esp.ps1";
 
-// Clean the environment for Windows.
+/// Clean the environment for Windows.
 pub(super) fn clean_env(_install_dir: &Path) -> Result<(), Error> {
     delete_env_variable("LIBCLANG_PATH")?;
     delete_env_variable("CLANG_PATH")?;
@@ -70,7 +72,7 @@ fn set_env_variable(key: &str, value: &str) -> Result<(), Error> {
     Ok(())
 }
 
-// Delete the legacy export file.
+/// Delete the legacy export file.
 fn remove_legacy_export_file() -> Result<(), Error> {
     let legacy_file = get_home_dir().join(LEGACY_EXPORT_FILE);
     if legacy_file.exists() {
@@ -123,7 +125,7 @@ pub(super) fn update_env() -> Result<(), Error> {
     Ok(())
 }
 
-// Write the environment files for Windows.
+/// Write the environment files for Windows.
 pub(super) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
     let windows_shells: Vec<shell::Shell> =
         vec![Box::new(shell::Batch), Box::new(shell::Powershell)];

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -47,7 +47,8 @@ pub(crate) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
 pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     let path = std::env::var_os("PATH").unwrap_or_default();
     set_environment_variable("PATH", path)?;
-
+    // TODO: REVIEW THIS - DO WE NEED TO SET THE X_GCC ENV?
+    // TODO: ARE WE ADDING X_GCC TO THE PATH?
     let xtensa_gcc = std::env::var_os("XTENSA_GCC").unwrap_or_default();
     set_environment_variable("XTENSA_GCC", xtensa_gcc)?;
 
@@ -63,6 +64,18 @@ pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     if let Some(libclang_path) = clang_path {
         set_environment_variable("CLANG_PATH", clang_path)?;
     }
+
+    remove_legacy_export_file()?;
+
+    Ok(())
+}
+
+pub(crate) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
+    delete_environment_variable("LIBCLANG_PATH")?;
+    delete_environment_variable("CLANG_PATH")?;
+    if let Some(path) = env::var("PATH") {
+        set_environment_variable("PATH", &path)?;
+    };
 
     remove_legacy_export_file()?;
 

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -34,7 +34,7 @@ pub fn delete_environment_variable(key: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn do_write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
+pub(crate) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
     let windows_shells: Vec<shell::Shell> = vec![Box::new(Batch), Box::new(Powershell)];
     for sh in windows_shells.into_iter() {
         let script = sh.env_script(toolchain_dir);
@@ -44,7 +44,7 @@ pub(crate) fn do_write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn do_add_to_path(toolchain_dir: &Path) -> Result<(), Error> {
+pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     let path = std::env::var_os("PATH").unwrap_or_default();
     set_environment_variable("PATH", path)?;
 
@@ -77,4 +77,3 @@ fn remove_legacy_export_file() -> Result<(), Error> {
 
     Ok(())
 }
-// TODO: REMOVE LEGACY FILE

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -9,7 +9,7 @@ use winreg::{
 const LEGACY_EXPORT_FILE: &str = "export-esp.ps1";
 
 // Clean the environment for Windows.
-pub(super) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
+pub(super) fn clean_env(_install_dir: &Path) -> Result<(), Error> {
     delete_env_variable("LIBCLANG_PATH")?;
     delete_env_variable("CLANG_PATH")?;
     if let Some(path) = env::var_os("PATH") {
@@ -56,28 +56,31 @@ fn remove_legacy_export_file() -> Result<(), Error> {
 }
 
 // Update the environment for Windows.
-pub(super) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
+pub(super) fn update_env() -> Result<(), Error> {
     let mut path = env::var("PATH").unwrap_or_default();
 
-    if let Some(xtensa_gcc) = env::var_os("XTENSA_GCC") {
-        if !path.contains(xtensa_gcc.into()) {
-            path = format!("{};{}", xtensa_gcc.into(), path);
+    if let Ok(xtensa_gcc) = env::var("XTENSA_GCC") {
+        let xtensa_gcc: &str = &xtensa_gcc;
+        if !path.contains(xtensa_gcc) {
+            path = format!("{};{}", xtensa_gcc, path);
         }
     }
 
-    if let Some(riscv_gcc) = env::var_os("RISCV_GCC") {
-        if !path.contains(riscv_gcc.into()) {
-            path = format!("{};{}", riscv_gcc.into(), path);
+    if let Ok(riscv_gcc) = env::var("RISCV_GCC") {
+        let riscv_gcc: &str = &riscv_gcc;
+        if !path.contains(riscv_gcc) {
+            path = format!("{};{}", riscv_gcc, path);
         }
     }
 
-    if let Some(libclang_path) = env::var_os("LIBCLANG_PATH") {
-        set_env_variable("LIBCLANG_PATH", &libclang_path.to_string_lossy())?;
+    if let Ok(libclang_path) = env::var("LIBCLANG_PATH") {
+        set_env_variable("LIBCLANG_PATH", &libclang_path)?;
     }
 
-    if let Some(clang_path) = env::var_os("CLANG_PATH") {
-        if !path.contains(clang_path.into()) {
-            path = format!("{};{}", clang_path.into(), path);
+    if let Ok(clang_path) = env::var("CLANG_PATH") {
+        let clang_path: &str = &clang_path;
+        if !path.contains(clang_path) {
+            path = format!("{};{}", clang_path, path);
         }
     }
     set_env_variable("PATH", &path)?;

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -77,12 +77,20 @@ pub(super) fn update_env() -> Result<(), Error> {
         set_env_variable("LIBCLANG_PATH", &libclang_path)?;
     }
 
+    if let Ok(libclang_bin_path) = env::var("LIBCLANG_BIN_PATH") {
+        let libclang_bin_path: &str = &libclang_bin_path;
+        if !path.contains(libclang_bin_path) {
+            path = format!("{};{}", libclang_bin_path, path);
+        }
+    }
+
     if let Ok(clang_path) = env::var("CLANG_PATH") {
         let clang_path: &str = &clang_path;
         if !path.contains(clang_path) {
             path = format!("{};{}", clang_path, path);
         }
     }
+
     set_env_variable("PATH", &path)?;
 
     remove_legacy_export_file()?;

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -1,9 +1,6 @@
-use crate::{env::get_home_dir, error::Error};
+use crate::{env::get_home_dir, env::shell, error::Error};
 use miette::Result;
-use std::{
-    env,
-    fs::{remove_file, Path},
-};
+use std::{env, fs::remove_file, path::Path};
 use winreg::{
     enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE},
     RegKey,
@@ -15,8 +12,8 @@ const LEGACY_EXPORT_FILE: &str = "export-esp.ps1";
 pub(super) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
     delete_env_variable("LIBCLANG_PATH")?;
     delete_env_variable("CLANG_PATH")?;
-    if let Some(path) = env::var("PATH") {
-        set_env_variable("PATH", &path)?;
+    if let Some(path) = env::var_os("PATH") {
+        set_env_variable("PATH", &path.to_string_lossy())?;
     };
 
     remove_legacy_export_file()?;
@@ -26,7 +23,7 @@ pub(super) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
 
 /// Deletes an environment variable for the current user.
 fn delete_env_variable(key: &str) -> Result<(), Error> {
-    if env::var(key).is_none() {
+    if env::var(key).is_ok() {
         return Ok(());
     }
 
@@ -62,26 +59,25 @@ fn remove_legacy_export_file() -> Result<(), Error> {
 pub(super) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     let mut path = env::var("PATH").unwrap_or_default();
 
-    // TODO: FIX THIS
-    if let Some(xtensa_gcc) = env::var("XTENSA_GCC") {
-        if !path.contains(xtensa_gcc) {
-            path = format!("{};{}", xtensa_gcc, path);
+    if let Some(xtensa_gcc) = env::var_os("XTENSA_GCC") {
+        if !path.contains(xtensa_gcc.into()) {
+            path = format!("{};{}", xtensa_gcc.into(), path);
         }
     }
 
-    if let Some(riscv_gcc) = env::var("RISCV_GCC") {
-        if !path.contains(riscv_gcc) {
-            path = format!("{};{}", riscv_gcc, path);
+    if let Some(riscv_gcc) = env::var_os("RISCV_GCC") {
+        if !path.contains(riscv_gcc.into()) {
+            path = format!("{};{}", riscv_gcc.into(), path);
         }
     }
 
-    if let Some(libclang_path) = env::var("LIBCLANG_PATH") {
-        set_env_variable("LIBCLANG_PATH", libclang_path)?;
+    if let Some(libclang_path) = env::var_os("LIBCLANG_PATH") {
+        set_env_variable("LIBCLANG_PATH", &libclang_path.to_string_lossy())?;
     }
 
-    if let Some(clang_path) = env::var("CLANG_PATH") {
-        if !path.contains(clang_path) {
-            path = format!("{};{}", clang_path, path);
+    if let Some(clang_path) = env::var_os("CLANG_PATH") {
+        if !path.contains(clang_path.into()) {
+            path = format!("{};{}", clang_path.into(), path);
         }
     }
     set_env_variable("PATH", &path)?;
@@ -93,7 +89,8 @@ pub(super) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
 
 // Write the environment files for Windows.
 pub(super) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
-    let windows_shells: Vec<shell::Shell> = vec![Box::new(Batch), Box::new(Powershell)];
+    let windows_shells: Vec<shell::Shell> =
+        vec![Box::new(shell::Batch), Box::new(shell::Powershell)];
     for sh in windows_shells.into_iter() {
         let script = sh.env_script(toolchain_dir);
         script.write()?;

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -1,0 +1,32 @@
+use log::warn;
+use std::env;
+use winreg::{
+    enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE},
+    RegKey,
+};
+
+#[cfg(windows)]
+/// Sets an environment variable for the current user.
+pub fn set_environment_variable(key: &str, value: &str) -> Result<(), Error> {
+    env::set_var(key, value);
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let environment_key = hkcu.open_subkey_with_flags("Environment", KEY_WRITE)?;
+    environment_key.set_value(key, &value)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+/// Deletes an environment variable for the current user.
+pub fn delete_environment_variable(key: &str) -> Result<(), Error> {
+    if env::var_os(key).is_none() {
+        return Ok(());
+    }
+
+    env::remove_var(key);
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let environment_key = hkcu.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)?;
+    environment_key.delete_value(key)?;
+    Ok(())
+}

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -1,5 +1,9 @@
-use log::warn;
-use std::env;
+use crate::env::get_home_dir;
+use miette::Result;
+use std::{
+    env,
+    fs::{remove_file, Path},
+};
 use winreg::{
     enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE},
     RegKey,
@@ -58,6 +62,7 @@ fn remove_legacy_export_file() -> Result<(), Error> {
 pub(super) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
     let mut path = std::env::var("PATH").unwrap_or_default();
 
+    // TODO: FIX THIS
     if let Some(xtensa_gcc) = std::env::var("XTENSA_GCC") {
         if !path.contains(xtensa_gcc) {
             path = format!("{};{}", xtensa_gcc, path);
@@ -79,7 +84,7 @@ pub(super) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
             path = format!("{};{}", clang_path, path);
         }
     }
-    set_env_variable("PATH", path)?;
+    set_env_variable("PATH", &path)?;
 
     remove_legacy_export_file()?;
 

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -7,21 +7,21 @@ use winreg::{
 
 const LEGACY_EXPORT_FILE: &str = "export-esp.ps1";
 
-// TODO: REVIEW CFGS
-#[cfg(windows)]
-/// Sets an environment variable for the current user.
-pub fn set_environment_variable(key: &str, value: &str) -> Result<(), Error> {
-    env::set_var(key, value);
+// Clean the environment for Windows.
+pub(super) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
+    delete_env_variable("LIBCLANG_PATH")?;
+    delete_env_variable("CLANG_PATH")?;
+    if let Some(path) = env::var("PATH") {
+        set_env_variable("PATH", &path)?;
+    };
 
-    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    let environment_key = hkcu.open_subkey_with_flags("Environment", KEY_WRITE)?;
-    environment_key.set_value(key, &value)?;
+    remove_legacy_export_file()?;
+
     Ok(())
 }
 
-#[cfg(windows)]
 /// Deletes an environment variable for the current user.
-pub fn delete_environment_variable(key: &str) -> Result<(), Error> {
+fn delete_env_variable(key: &str) -> Result<(), Error> {
     if env::var_os(key).is_none() {
         return Ok(());
     }
@@ -34,58 +34,59 @@ pub fn delete_environment_variable(key: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub(crate) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
-    let windows_shells: Vec<shell::Shell> = vec![Box::new(Batch), Box::new(Powershell)];
-    for sh in windows_shells.into_iter() {
-        let script = sh.env_script(toolchain_dir);
-        script.write()?;
-    }
+/// Sets an environment variable for the current user.
+fn set_env_variable(key: &str, value: &str) -> Result<(), Error> {
+    env::set_var(key, value);
 
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let environment_key = hkcu.open_subkey_with_flags("Environment", KEY_WRITE)?;
+    environment_key.set_value(key, &value)?;
     Ok(())
 }
 
-pub(crate) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
-    let path = std::env::var_os("PATH").unwrap_or_default();
-    set_environment_variable("PATH", path)?;
-    // TODO: REVIEW THIS - DO WE NEED TO SET THE X_GCC ENV?
-    // TODO: ARE WE ADDING X_GCC TO THE PATH?
-    let xtensa_gcc = std::env::var_os("XTENSA_GCC").unwrap_or_default();
-    set_environment_variable("XTENSA_GCC", xtensa_gcc)?;
-
-    let riscv_gcc = std::env::var_os("RISCV_GCC").unwrap_or_default();
-    set_environment_variable("RISCV_GCC", riscv_gcc)?;
-
-    let libclang_path = std::env::var_os("LIBCLANG_PATH");
-    if let Some(libclang_path) = libclang_path {
-        set_environment_variable("LIBCLANG_PATH", libclang_path)?;
-    }
-
-    let clang_path = std::env::var_os("CLANG_PATH");
-    if let Some(libclang_path) = clang_path {
-        set_environment_variable("CLANG_PATH", clang_path)?;
-    }
-
-    remove_legacy_export_file()?;
-
-    Ok(())
-}
-
-pub(crate) fn clean_env(toolchain_dir: &Path) -> Result<(), Error> {
-    delete_environment_variable("LIBCLANG_PATH")?;
-    delete_environment_variable("CLANG_PATH")?;
-    if let Some(path) = env::var("PATH") {
-        set_environment_variable("PATH", &path)?;
-    };
-
-    remove_legacy_export_file()?;
-
-    Ok(())
-}
-
+// Delete the legacy export file.
 fn remove_legacy_export_file() -> Result<(), Error> {
     let legacy_file = get_home_dir().join(LEGACY_EXPORT_FILE);
     if legacy_file.exists() {
         remove_file(&legacy_file)?;
+    }
+
+    Ok(())
+}
+
+// Update the environment for Windows.
+pub(super) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    set_env_variable("PATH", path)?;
+    // TODO: REVIEW THIS - DO WE NEED TO SET THE X_GCC ENV?
+    // TODO: ARE WE ADDING X_GCC TO THE PATH?
+    let xtensa_gcc = std::env::var_os("XTENSA_GCC").unwrap_or_default();
+    set_env_variable("XTENSA_GCC", xtensa_gcc)?;
+
+    let riscv_gcc = std::env::var_os("RISCV_GCC").unwrap_or_default();
+    set_env_variable("RISCV_GCC", riscv_gcc)?;
+
+    let libclang_path = std::env::var_os("LIBCLANG_PATH");
+    if let Some(libclang_path) = libclang_path {
+        set_env_variable("LIBCLANG_PATH", libclang_path)?;
+    }
+
+    let clang_path = std::env::var_os("CLANG_PATH");
+    if let Some(libclang_path) = clang_path {
+        set_env_variable("CLANG_PATH", clang_path)?;
+    }
+
+    remove_legacy_export_file()?;
+
+    Ok(())
+}
+
+// Write the environment files for Windows.
+pub(super) fn write_env_files(toolchain_dir: &Path) -> Result<(), Error> {
+    let windows_shells: Vec<shell::Shell> = vec![Box::new(Batch), Box::new(Powershell)];
+    for sh in windows_shells.into_iter() {
+        let script = sh.env_script(toolchain_dir);
+        script.write()?;
     }
 
     Ok(())

--- a/src/env/windows.rs
+++ b/src/env/windows.rs
@@ -1,4 +1,4 @@
-use crate::env::get_home_dir;
+use crate::{env::get_home_dir, error::Error};
 use miette::Result;
 use std::{
     env,
@@ -60,26 +60,26 @@ fn remove_legacy_export_file() -> Result<(), Error> {
 
 // Update the environment for Windows.
 pub(super) fn update_env(toolchain_dir: &Path) -> Result<(), Error> {
-    let mut path = std::env::var("PATH").unwrap_or_default();
+    let mut path = env::var("PATH").unwrap_or_default();
 
     // TODO: FIX THIS
-    if let Some(xtensa_gcc) = std::env::var("XTENSA_GCC") {
+    if let Some(xtensa_gcc) = env::var("XTENSA_GCC") {
         if !path.contains(xtensa_gcc) {
             path = format!("{};{}", xtensa_gcc, path);
         }
     }
 
-    if let Some(riscv_gcc) = std::env::var("RISCV_GCC") {
+    if let Some(riscv_gcc) = env::var("RISCV_GCC") {
         if !path.contains(riscv_gcc) {
             path = format!("{};{}", riscv_gcc, path);
         }
     }
 
-    if let Some(libclang_path) = std::env::var("LIBCLANG_PATH") {
+    if let Some(libclang_path) = env::var("LIBCLANG_PATH") {
         set_env_variable("LIBCLANG_PATH", libclang_path)?;
     }
 
-    if let Some(clang_path) = std::env::var("CLANG_PATH") {
+    if let Some(clang_path) = env::var("CLANG_PATH") {
         if !path.contains(clang_path) {
             path = format!("{};{}", clang_path, path);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,10 @@ pub enum Error {
         "Invalid export file destination: '{0}'. Please, use an absolute or releative path (including the file and its extension)")]
     InvalidDestination(String),
 
+    #[diagnostic(code(espup::env::home_dir))]
+    #[error("Failed to query GitHub API")]
+    InvalidHome,
+
     #[diagnostic(code(espup::toolchain::rust::invalid_version))]
     #[error(
         "Invalid toolchain version '{0}'. Verify that the format is correct: '<major>.<minor>.<patch>.<subpatch>' or '<major>.<minor>.<patch>', and that the release exists in https://github.com/esp-rs/rust-build/releases")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,4 +69,6 @@ pub enum Error {
     #[diagnostic(code(espup::toolchain::rust::rust_src))]
     #[error("Failed to install 'rust-src' component of Xtensa Rust")]
     XtensaRustSrc,
+    // #[error(transparent)]
+    // Zsh(#[from] std::io::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,4 +75,8 @@ pub enum Error {
     #[diagnostic(code(espup::env::unix))]
     #[error("Failed to read {name} file: '{}'", .path.display())]
     ReadingFile { name: &'static str, path: PathBuf },
+
+    #[diagnostic(code(espup::env::shell))]
+    #[error("ZDOTDIR not set")]
+    Zdotdir,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! Custom error implementations.
 
+use std::path::PathBuf;
+
 #[derive(Debug, miette::Diagnostic, thiserror::Error)]
 pub enum Error {
     #[diagnostic(code(espup::toolchain::create_directory))]
@@ -69,6 +71,8 @@ pub enum Error {
     #[diagnostic(code(espup::toolchain::rust::rust_src))]
     #[error("Failed to install 'rust-src' component of Xtensa Rust")]
     XtensaRustSrc,
-    // #[error(transparent)]
-    // Zsh(#[from] std::io::Error),
+
+    #[diagnostic(code(espup::env::unix))]
+    #[error("Failed to read {name} file: '{}'", .path.display())]
+    ReadingFile { name: &'static str, path: PathBuf },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,12 +74,14 @@ async fn uninstall(args: UninstallOpts) -> Result<()> {
 
     uninstall_gcc_toolchains(&install_dir)?;
 
-    info!(
-        "Deleting the Xtensa Rust toolchain located in '{}'",
-        &install_dir.display()
-    );
-    remove_dir_all(&install_dir)
-        .map_err(|_| Error::RemoveDirectory(install_dir.display().to_string()))?;
+    if install_dir.exists() {
+        info!(
+            "Deleting the Xtensa Rust toolchain located in '{}'",
+            &install_dir.display()
+        );
+        remove_dir_all(&install_dir)
+            .map_err(|_| Error::RemoveDirectory(install_dir.display().to_string()))?;
+    }
 
     clean_env(&install_dir)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
 use clap::{CommandFactory, Parser};
-#[cfg(windows)]
-use espup::env::set_environment_variable;
-#[cfg(unix)]
-use espup::env::unix;
 use espup::{
     cli::{CompletionsOpts, InstallOpts, UninstallOpts},
+    env::clean_env,
     error::Error,
     logging::initialize_logger,
     toolchain::{
@@ -84,10 +81,7 @@ async fn uninstall(args: UninstallOpts) -> Result<()> {
     remove_dir_all(&install_dir)
         .map_err(|_| Error::RemoveDirectory(install_dir.display().to_string()))?;
 
-    #[cfg(windows)]
-    set_environment_variable("PATH", &env::var("PATH").unwrap())?;
-    #[cfg(unix)]
-    unix::do_remove_from_path(&install_dir)?;
+    clean_env(&install_dir)?;
 
     info!("Uninstallation successfully completed!");
     Ok(())

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -93,9 +93,13 @@ impl Installable for Gcc {
             );
         }
         #[cfg(unix)]
-        if cfg!(windows) {
+        if cfg!(unix) {
             exports.push(format!("export PATH=\"{}:$PATH\"", &self.get_bin_path()));
-            // TODO: Write env files?
+            if self.arch == RISCV_GCC {
+                std::env::set_var("RISCV_GCC", self.get_bin_path());
+            } else {
+                std::env::set_var("XTENSA_GCC", self.get_bin_path());
+            }
         }
         Ok(exports)
     }

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -32,7 +32,12 @@ pub struct Gcc {
 impl Gcc {
     /// Gets the binary path.
     fn get_bin_path(&self) -> String {
-        format!("{}/{}/bin", &self.path.to_str().unwrap(), &self.arch)
+        #[cfg(windows)]
+        let bin_path =
+            format!("{}/{}/bin", &self.path.to_str().unwrap(), &self.arch).replace('/', "\\");
+        #[cfg(unix)]
+        let bin_path = format!("{}/{}/bin", &self.path.to_str().unwrap(), &self.arch);
+        bin_path
     }
 
     /// Create a new instance with default values and proper toolchain name.
@@ -81,23 +86,12 @@ impl Installable for Gcc {
             .await?;
         }
 
-        #[cfg(windows)]
-        if cfg!(windows) {
-            let windows_path = self.get_bin_path().replace('/', "\\");
-            if self.arch == RISCV_GCC {
-                env::set_var("RISCV_GCC", self.get_bin_path());
-            } else {
-                env::set_var("XTENSA_GCC", self.get_bin_path());
-            }
+        if self.arch == RISCV_GCC {
+            env::set_var("RISCV_GCC", self.get_bin_path());
+        } else {
+            env::set_var("XTENSA_GCC", self.get_bin_path());
         }
-        #[cfg(unix)]
-        if cfg!(unix) {
-            if self.arch == RISCV_GCC {
-                env::set_var("RISCV_GCC", self.get_bin_path());
-            } else {
-                env::set_var("XTENSA_GCC", self.get_bin_path());
-            }
-        }
+
         Ok(())
     }
 

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use log::{debug, info, warn};
 use miette::Result;
 use std::{
+    env,
     fs::remove_dir_all,
     path::{Path, PathBuf},
 };
@@ -84,17 +85,17 @@ impl Installable for Gcc {
         if cfg!(windows) {
             let windows_path = self.get_bin_path().replace('/', "\\");
             if self.arch == RISCV_GCC {
-                std::env::set_var("RISCV_GCC", self.get_bin_path());
+                env::set_var("RISCV_GCC", self.get_bin_path());
             } else {
-                std::env::set_var("XTENSA_GCC", self.get_bin_path());
+                env::set_var("XTENSA_GCC", self.get_bin_path());
             }
         }
         #[cfg(unix)]
         if cfg!(unix) {
             if self.arch == RISCV_GCC {
-                std::env::set_var("RISCV_GCC", self.get_bin_path());
+                env::set_var("RISCV_GCC", self.get_bin_path());
             } else {
-                std::env::set_var("XTENSA_GCC", self.get_bin_path());
+                env::set_var("XTENSA_GCC", self.get_bin_path());
             }
         }
         Ok(())
@@ -143,9 +144,9 @@ pub fn uninstall_gcc_toolchains(toolchain_path: &Path) -> Result<(), Error> {
                     DEFAULT_GCC_RELEASE,
                     toolchain
                 );
-                std::env::set_var(
+                env::set_var(
                     "PATH",
-                    std::env::var("PATH")
+                    env::var("PATH")
                         .unwrap()
                         .replace(&format!("{gcc_path};"), ""),
                 );

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -50,7 +50,7 @@ impl Gcc {
 
 #[async_trait]
 impl Installable for Gcc {
-    async fn install(&self) -> Result<Vec<String>, Error> {
+    async fn install(&self) -> Result<(), Error> {
         let extension = get_artifact_extension(&self.host_triple);
         debug!("GCC path: {}", self.path.display());
         if self.path.exists() {
@@ -79,14 +79,9 @@ impl Installable for Gcc {
             )
             .await?;
         }
-        let exports: Vec<String> = Vec::new();
 
         #[cfg(windows)]
         if cfg!(windows) {
-            // exports.push(format!(
-            //     "$Env:PATH = \"{};\" + $Env:PATH",
-            //     &self.get_bin_path()
-            // ));
             let windows_path = self.get_bin_path().replace('/', "\\");
             if self.arch == RISCV_GCC {
                 std::env::set_var("RISCV_GCC", self.get_bin_path());
@@ -96,14 +91,13 @@ impl Installable for Gcc {
         }
         #[cfg(unix)]
         if cfg!(unix) {
-            // exports.push(format!("export PATH=\"{}:$PATH\"", &self.get_bin_path()));
             if self.arch == RISCV_GCC {
                 std::env::set_var("RISCV_GCC", self.get_bin_path());
             } else {
                 std::env::set_var("XTENSA_GCC", self.get_bin_path());
             }
         }
-        Ok(exports)
+        Ok(())
     }
 
     fn name(&self) -> String {

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -30,7 +30,7 @@ pub struct Gcc {
 
 impl Gcc {
     /// Gets the binary path.
-    pub fn get_bin_path(&self) -> String {
+    fn get_bin_path(&self) -> String {
         format!("{}/{}/bin", &self.path.to_str().unwrap(), &self.arch)
     }
 

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -127,7 +127,6 @@ fn get_artifact_extension(host_triple: &HostTriple) -> &str {
 }
 
 /// Checks if the toolchain is pressent, if present uninstalls it.
-// TODO: REVIEW UNINSTALL METHODS
 pub fn uninstall_gcc_toolchains(toolchain_path: &Path) -> Result<(), Error> {
     info!("Uninstalling GCC");
 

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -93,8 +93,10 @@ impl Installable for Gcc {
             );
         }
         #[cfg(unix)]
-        exports.push(format!("export PATH=\"{}:$PATH\"", &self.get_bin_path()));
-
+        if cfg!(windows) {
+            exports.push(format!("export PATH=\"{}:$PATH\"", &self.get_bin_path()));
+            // TODO: Write env files?
+        }
         Ok(exports)
     }
 

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -58,6 +58,7 @@ impl Gcc {
 impl Installable for Gcc {
     async fn install(&self) -> Result<(), Error> {
         let extension = get_artifact_extension(&self.host_triple);
+        info!("Installing GCC ({})", self.arch);
         debug!("GCC path: {}", self.path.display());
         if self.path.exists() {
             warn!(

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -79,22 +79,24 @@ impl Installable for Gcc {
             )
             .await?;
         }
-        let mut exports: Vec<String> = Vec::new();
+        let exports: Vec<String> = Vec::new();
 
         #[cfg(windows)]
         if cfg!(windows) {
-            exports.push(format!(
-                "$Env:PATH = \"{};\" + $Env:PATH",
-                &self.get_bin_path()
-            ));
-            std::env::set_var(
-                "PATH",
-                self.get_bin_path().replace('/', "\\") + ";" + &std::env::var("PATH").unwrap(),
-            );
+            // exports.push(format!(
+            //     "$Env:PATH = \"{};\" + $Env:PATH",
+            //     &self.get_bin_path()
+            // ));
+            let windows_path = self.get_bin_path().replace('/', "\\");
+            if self.arch == RISCV_GCC {
+                std::env::set_var("RISCV_GCC", self.get_bin_path());
+            } else {
+                std::env::set_var("XTENSA_GCC", self.get_bin_path());
+            }
         }
         #[cfg(unix)]
         if cfg!(unix) {
-            exports.push(format!("export PATH=\"{}:$PATH\"", &self.get_bin_path()));
+            // exports.push(format!("export PATH=\"{}:$PATH\"", &self.get_bin_path()));
             if self.arch == RISCV_GCC {
                 std::env::set_var("RISCV_GCC", self.get_bin_path());
             } else {
@@ -131,6 +133,7 @@ fn get_artifact_extension(host_triple: &HostTriple) -> &str {
 }
 
 /// Checks if the toolchain is pressent, if present uninstalls it.
+// TODO: REVIEW UNINSTALL METHODS
 pub fn uninstall_gcc_toolchains(toolchain_path: &Path) -> Result<(), Error> {
     info!("Uninstalling GCC");
 

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -186,8 +186,10 @@ impl Installable for Llvm {
             );
         }
         #[cfg(unix)]
-        exports.push(format!("export LIBCLANG_PATH=\"{}\"", self.get_lib_path()));
-
+        if cfg!(unix) {
+            exports.push(format!("export LIBCLANG_PATH=\"{}\"", self.get_lib_path()));
+            std::env::set_var("LIBCLANG_PATH", self.get_lib_path());
+        }
         if self.extended {
             #[cfg(windows)]
             if cfg!(windows) {

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -149,9 +149,7 @@ impl Llvm {
 
 #[async_trait]
 impl Installable for Llvm {
-    async fn install(&self) -> Result<Vec<String>, Error> {
-        let mut exports: Vec<String> = Vec::new();
-
+    async fn install(&self) -> Result<(), Error> {
         if Path::new(&self.path).exists() {
             warn!(
                 "Previous installation of LLVM exists in: '{}'. Reusing this installation",
@@ -169,7 +167,6 @@ impl Installable for Llvm {
             .await?;
         }
         // Set environment variables.
-        // TODO: REMOVE EXPORTS
         #[cfg(windows)]
         std::env::set_var("LIBCLANG_BIN_PATH", self.get_lib_path());
         std::env::set_var("LIBCLANG_PATH", self.get_lib_path());
@@ -178,7 +175,7 @@ impl Installable for Llvm {
             std::env::set_var("CLANG_PATH", self.get_bin_path());
         }
 
-        Ok(exports)
+        Ok(())
     }
 
     fn name(&self) -> String {

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -55,7 +55,8 @@ impl Llvm {
         let llvm_path = format!(
             "{}/esp-clang/bin",
             self.path.to_str().unwrap().replace('/', "\\")
-        );
+        )
+        .replace('/', "\\");
         #[cfg(unix)]
         let llvm_path = format!("{}/esp-clang/lib", self.path.to_str().unwrap());
         llvm_path
@@ -64,8 +65,8 @@ impl Llvm {
     /// Gets the binary path of clang
     fn get_bin_path(&self) -> String {
         #[cfg(windows)]
-        let llvm_path =
-            format!("{}/esp-clang/bin/clang.exe", self.path.to_str().unwrap()).replace('/', "\\");
+        let llvm_path = format!("{}\\esp-clang\\bin\\clang.exe", self.path.to_str().unwrap())
+            .replace('/', "\\");
         #[cfg(unix)]
         let llvm_path = format!("{}/esp-clang/bin/clang", self.path.to_str().unwrap());
         llvm_path

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -177,7 +177,6 @@ impl Installable for Llvm {
         #[cfg(windows)]
         env::set_var("LIBCLANG_BIN_PATH", self.get_lib_path());
         env::set_var("LIBCLANG_PATH", self.get_lib_path());
-        // }
         if self.extended {
             env::set_var("CLANG_PATH", self.get_bin_path());
         }

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -127,8 +127,8 @@ impl Llvm {
         if llvm_path.exists() {
             #[cfg(windows)]
             if cfg!(windows) {
-                delete_environment_variable("LIBCLANG_PATH")?;
-                delete_environment_variable("CLANG_PATH")?;
+                std::env::remove_var("LIBCLANG_PATH");
+                std::env::remove_var("CLANG_PATH");
                 let updated_path = std::env::var("PATH").unwrap().replace(
                     &format!(
                         "{}\\{}\\esp-clang\\bin;",
@@ -137,11 +137,10 @@ impl Llvm {
                     ),
                     "",
                 );
-                set_environment_variable("PATH", &updated_path)?;
+                std::env::set_var("PATH", updated_path);
             }
-            let path = toolchain_path.join(CLANG_NAME);
-            remove_dir_all(&path)
-                .map_err(|_| Error::RemoveDirectory(path.display().to_string()))?;
+            remove_dir_all(&llvm_path)
+                .map_err(|_| Error::RemoveDirectory(llvm_path.display().to_string()))?;
         }
         Ok(())
     }

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -10,6 +10,7 @@ use log::{info, warn};
 use miette::Result;
 use regex::Regex;
 use std::{
+    env,
     fs::remove_dir_all,
     path::{Path, PathBuf},
     u8,
@@ -125,9 +126,9 @@ impl Llvm {
         if llvm_path.exists() {
             #[cfg(windows)]
             if cfg!(windows) {
-                std::env::remove_var("LIBCLANG_PATH");
-                std::env::remove_var("CLANG_PATH");
-                let updated_path = std::env::var("PATH").unwrap().replace(
+                env::remove_var("LIBCLANG_PATH");
+                env::remove_var("CLANG_PATH");
+                let updated_path = env::var("PATH").unwrap().replace(
                     &format!(
                         "{}\\{}\\esp-clang\\bin;",
                         llvm_path.display().to_string().replace('/', "\\"),
@@ -135,7 +136,7 @@ impl Llvm {
                     ),
                     "",
                 );
-                std::env::set_var("PATH", updated_path);
+                env::set_var("PATH", updated_path);
             }
             remove_dir_all(&llvm_path)
                 .map_err(|_| Error::RemoveDirectory(llvm_path.display().to_string()))?;
@@ -165,11 +166,11 @@ impl Installable for Llvm {
         }
         // Set environment variables.
         #[cfg(windows)]
-        std::env::set_var("LIBCLANG_BIN_PATH", self.get_lib_path());
-        std::env::set_var("LIBCLANG_PATH", self.get_lib_path());
+        env::set_var("LIBCLANG_BIN_PATH", self.get_lib_path());
+        env::set_var("LIBCLANG_PATH", self.get_lib_path());
         // }
         if self.extended {
-            std::env::set_var("CLANG_PATH", self.get_bin_path());
+            env::set_var("CLANG_PATH", self.get_bin_path());
         }
 
         Ok(())

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -129,11 +129,19 @@ impl Llvm {
             if cfg!(windows) {
                 env::remove_var("LIBCLANG_PATH");
                 env::remove_var("CLANG_PATH");
-                let updated_path = env::var("PATH").unwrap().replace(
+                let mut updated_path = env::var("PATH").unwrap().replace(
                     &format!(
                         "{}\\{}\\esp-clang\\bin;",
                         llvm_path.display().to_string().replace('/', "\\"),
                         DEFAULT_LLVM_15_VERSION,
+                    ),
+                    "",
+                );
+                updated_path = updated_path.replace(
+                    &format!(
+                        "{}\\{}\\esp-clang\\bin;",
+                        llvm_path.display().to_string().replace('/', "\\"),
+                        DEFAULT_LLVM_16_VERSION,
                     ),
                     "",
                 );

--- a/src/toolchain/llvm.rs
+++ b/src/toolchain/llvm.rs
@@ -1,7 +1,5 @@
 //! LLVM Toolchain source and installation tools.
 
-#[cfg(windows)]
-use crate::env::{delete_environment_variable, set_environment_variable};
 use crate::{
     error::Error,
     host_triple::HostTriple,

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -245,9 +245,9 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
         InstallMode::Install => info!("Installation successfully completed!"),
         InstallMode::Update => info!("Update successfully completed!"),
     }
-    if !args.no_modify_env {
-        set_env(&toolchain_dir)?;
-    }
+
+    set_env(&toolchain_dir, args.no_modify_env)?;
+
     print_post_install_msg(&toolchain_dir.display().to_string(), args.no_modify_env);
 
     Ok(())

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     cli::InstallOpts,
-    env::{create_export_file, export_environment, get_export_file},
+    env::{export_environment, get_export_file},
     error::Error,
     host_triple::get_host_triple,
     targets::Target,
@@ -246,7 +246,7 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
         exports.extend(names);
     }
 
-    create_export_file(&export_file, &exports)?;
+    // create_export_file(&export_file, &exports)?;
     match install_mode {
         InstallMode::Install => info!("Installation successfully completed!"),
         InstallMode::Update => info!("Update successfully completed!"),

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     cli::InstallOpts,
-    env::{export_environment, get_export_file},
+    env::{get_export_file, print_post_install_msg, set_environment},
     error::Error,
     host_triple::get_host_triple,
     targets::Target,
@@ -251,7 +251,11 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
         InstallMode::Install => info!("Installation successfully completed!"),
         InstallMode::Update => info!("Update successfully completed!"),
     }
-    export_environment(&export_file, &toolchain_dir)?;
+    if !args.no_modify_env {
+        set_environment(&toolchain_dir)?;
+    }
+    print_post_install_msg(&toolchain_dir.display().to_string(), args.no_modify_env);
+
     Ok(())
 }
 

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -63,11 +63,11 @@ pub(super) async fn download_file(
         );
         remove_file(&file_path)?;
     } else if !Path::new(&output_directory).exists() {
-        info!("Creating directory: '{}'", output_directory);
+        debug!("Creating directory: '{}'", output_directory);
         create_dir_all(output_directory)
             .map_err(|_| Error::CreateDirectory(output_directory.to_string()))?;
     }
-    info!("Downloading file '{}' from '{}'", &file_path, url);
+    info!("Downloading '{}'", &file_name);
     let resp = reqwest::get(&url).await?;
     let bytes = resp.bytes().await?;
     if uncompress {
@@ -101,7 +101,7 @@ pub(super) async fn download_file(
                 }
             }
             "gz" => {
-                info!("Extracting tar.gz file to '{}'", output_directory);
+                debug!("Extracting tar.gz file to '{}'", output_directory);
 
                 let bytes = bytes.to_vec();
                 let tarfile = GzDecoder::new(bytes.as_slice());
@@ -109,7 +109,7 @@ pub(super) async fn download_file(
                 archive.unpack(output_directory)?;
             }
             "xz" => {
-                info!("Extracting tar.xz file to '{}'", output_directory);
+                debug!("Extracting tar.xz file to '{}'", output_directory);
                 let bytes = bytes.to_vec();
                 let tarfile = XzDecoder::new(bytes.as_slice());
                 let mut archive = Archive::new(tarfile);
@@ -120,7 +120,7 @@ pub(super) async fn download_file(
             }
         }
     } else {
-        info!("Creating file: '{}'", file_path);
+        debug!("Creating file: '{}'", file_path);
         let mut out = File::create(&file_path)?;
         out.write_all(&bytes)?;
     }
@@ -255,7 +255,7 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
 
 /// Queries the GitHub API and returns the JSON response.
 pub(super) fn github_query(url: &str) -> Result<serde_json::Value, Error> {
-    info!("Querying GitHub API: '{}'", url);
+    debug!("Querying GitHub API: '{}'", url);
     let mut headers = header::HeaderMap::new();
     headers.insert(header::USER_AGENT, "espup".parse().unwrap());
     headers.insert(

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     cli::InstallOpts,
-    env::{print_post_install_msg, set_environment},
+    env::{print_post_install_msg, set_env},
     error::Error,
     host_triple::get_host_triple,
     targets::Target,
@@ -48,7 +48,7 @@ pub trait Installable {
 }
 
 /// Downloads a file from a URL and uncompresses it, if necesary, to the output directory.
-pub async fn download_file(
+pub(super) async fn download_file(
     url: String,
     file_name: &str,
     output_directory: &str,
@@ -246,7 +246,7 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
         InstallMode::Update => info!("Update successfully completed!"),
     }
     if !args.no_modify_env {
-        set_environment(&toolchain_dir)?;
+        set_env(&toolchain_dir)?;
     }
     print_post_install_msg(&toolchain_dir.display().to_string(), args.no_modify_env);
 
@@ -254,7 +254,7 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
 }
 
 /// Queries the GitHub API and returns the JSON response.
-pub fn github_query(url: &str) -> Result<serde_json::Value, Error> {
+pub(super) fn github_query(url: &str) -> Result<serde_json::Value, Error> {
     info!("Querying GitHub API: '{}'", url);
     let mut headers = header::HeaderMap::new();
     headers.insert(header::USER_AGENT, "espup".parse().unwrap());

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -182,7 +182,7 @@ impl XtensaRust {
 
 #[async_trait]
 impl Installable for XtensaRust {
-    async fn install(&self) -> Result<Vec<String>, Error> {
+    async fn install(&self) -> Result<(), Error> {
         if self.toolchain_destination.exists() {
             let toolchain_name = format!(
                 "+{}",
@@ -203,7 +203,7 @@ impl Installable for XtensaRust {
                 &self.version,
                 &self.toolchain_destination.display()
             );
-                return Ok(vec![]);
+                return Ok(());
             } else {
                 if !rustc_version.status.success() {
                     warn!("Failed to detect version of Xtensa Rust, reinstalling it");
@@ -299,7 +299,7 @@ impl Installable for XtensaRust {
             .await?;
         }
 
-        Ok(vec![]) // No exports
+        Ok(())
     }
 
     fn name(&self) -> String {
@@ -346,7 +346,7 @@ impl RiscVTarget {
 
 #[async_trait]
 impl Installable for RiscVTarget {
-    async fn install(&self) -> Result<Vec<String>, Error> {
+    async fn install(&self) -> Result<(), Error> {
         info!(
             "Installing RISC-V Rust targets ('riscv32imc-unknown-none-elf' and 'riscv32imac-unknown-none-elf') for '{}' toolchain",            &self.nightly_version
         );
@@ -372,7 +372,7 @@ impl Installable for RiscVTarget {
             return Err(Error::InstallRiscvTarget(self.nightly_version.clone()));
         }
 
-        Ok(vec![]) // No exports
+        Ok(())
     }
 
     fn name(&self) -> String {

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -405,7 +405,7 @@ pub fn get_rustup_home() -> PathBuf {
 }
 
 /// Checks if rustup is installed.
-pub async fn check_rust_installation() -> Result<(), Error> {
+pub(super) async fn check_rust_installation() -> Result<(), Error> {
     info!("Checking Rust installation");
 
     if let Err(e) = Command::new("rustup")

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -1,6 +1,7 @@
 //! Xtensa Rust Toolchain source and installation tools.
 
 use crate::{
+    env::get_home_dir,
     error::Error,
     host_triple::HostTriple,
     toolchain::{
@@ -12,7 +13,6 @@ use crate::{
     },
 };
 use async_trait::async_trait;
-use directories::BaseDirs;
 use log::{debug, info, warn};
 use miette::Result;
 use regex::Regex;
@@ -390,26 +390,18 @@ fn get_artifact_extension(host_triple: &HostTriple) -> &str {
 
 /// Gets the default cargo home path.
 fn get_cargo_home() -> PathBuf {
-    PathBuf::from(env::var("CARGO_HOME").unwrap_or_else(|_e| {
-        format!(
-            "{}",
-            BaseDirs::new().unwrap().home_dir().join(".cargo").display()
-        )
-    }))
+    PathBuf::from(
+        env::var("CARGO_HOME")
+            .unwrap_or_else(|_e| format!("{}", get_home_dir().join(".cargo").display())),
+    )
 }
 
 /// Gets the default rustup home path.
 pub fn get_rustup_home() -> PathBuf {
-    PathBuf::from(env::var("RUSTUP_HOME").unwrap_or_else(|_e| {
-        format!(
-            "{}",
-            BaseDirs::new()
-                .unwrap()
-                .home_dir()
-                .join(".rustup")
-                .display()
-        )
-    }))
+    PathBuf::from(
+        env::var("RUSTUP_HOME")
+            .unwrap_or_else(|_e| format!("{}", get_home_dir().join(".rustup").display())),
+    )
 }
 
 /// Checks if rustup is installed.
@@ -434,10 +426,10 @@ pub async fn check_rust_installation() -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        env::get_home_dir,
         logging::initialize_logger,
         toolchain::rust::{get_cargo_home, get_rustup_home, XtensaRust},
     };
-    use directories::BaseDirs;
 
     #[test]
     fn test_xtensa_rust_parse_version() {
@@ -460,10 +452,7 @@ mod tests {
     fn test_get_cargo_home() {
         // No CARGO_HOME set
         std::env::remove_var("CARGO_HOME");
-        assert_eq!(
-            get_cargo_home(),
-            BaseDirs::new().unwrap().home_dir().join(".cargo")
-        );
+        assert_eq!(get_cargo_home(), get_home_dir().join(".cargo"));
         // CARGO_HOME set
         let temp_dir = tempfile::TempDir::new().unwrap();
         let cargo_home = temp_dir.path().to_path_buf();
@@ -475,10 +464,7 @@ mod tests {
     fn test_get_rustup_home() {
         // No RUSTUP_HOME set
         std::env::remove_var("RUSTUP_HOME");
-        assert_eq!(
-            get_rustup_home(),
-            BaseDirs::new().unwrap().home_dir().join(".rustup")
-        );
+        assert_eq!(get_rustup_home(), get_home_dir().join(".rustup"));
         // RUSTUP_HOME set
         let temp_dir = tempfile::TempDir::new().unwrap();
         let rustup_home = temp_dir.path().to_path_buf();

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -430,6 +430,7 @@ mod tests {
         logging::initialize_logger,
         toolchain::rust::{get_cargo_home, get_rustup_home, XtensaRust},
     };
+    use std::env;
 
     #[test]
     fn test_xtensa_rust_parse_version() {

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -451,24 +451,24 @@ mod tests {
     #[test]
     fn test_get_cargo_home() {
         // No CARGO_HOME set
-        std::env::remove_var("CARGO_HOME");
+        env::remove_var("CARGO_HOME");
         assert_eq!(get_cargo_home(), get_home_dir().join(".cargo"));
         // CARGO_HOME set
         let temp_dir = tempfile::TempDir::new().unwrap();
         let cargo_home = temp_dir.path().to_path_buf();
-        std::env::set_var("CARGO_HOME", cargo_home.to_str().unwrap());
+        env::set_var("CARGO_HOME", cargo_home.to_str().unwrap());
         assert_eq!(get_cargo_home(), cargo_home);
     }
 
     #[test]
     fn test_get_rustup_home() {
         // No RUSTUP_HOME set
-        std::env::remove_var("RUSTUP_HOME");
+        env::remove_var("RUSTUP_HOME");
         assert_eq!(get_rustup_home(), get_home_dir().join(".rustup"));
         // RUSTUP_HOME set
         let temp_dir = tempfile::TempDir::new().unwrap();
         let rustup_home = temp_dir.path().to_path_buf();
-        std::env::set_var("RUSTUP_HOME", rustup_home.to_str().unwrap());
+        env::set_var("RUSTUP_HOME", rustup_home.to_str().unwrap());
         assert_eq!(get_rustup_home(), rustup_home);
     }
 }


### PR DESCRIPTION
This PR basically copies how [rustup](https://github.com/rust-lang/rustup/blob/master/src/cli/self_update/shell.rs) handles the user environment modification.
- Added a `--no-modify-env` flag that avoids modifying the user environment.
- In Unix systems, we will try to detect the available shells, and write the source command in the shell rc files.
  - Uninstall command will clear the rc files too.
  - Two exports scripts, `.sh` and `.fish` are generated  `$HOME/.rustup/toolchain/<esp_toolchain>`
    - In case the user is using the `--no-modify-env` flag, he needs to source one of these files.
- In Windows systems, we will set the proper environment variables, unless the `-no-modify-env` flag is used. (we already do this)
  - Uninstall command will remove the proper environment variables 
  - Two export scripts, `.bat` and `.ps1`, are generated under `$HOME/.rustup/toolchain/<esp_toolchain>`
    - In case the user is using the `--no-modify-env` flag, he needs to source one of these files.
- Adjusted the logs to be more like `rustup`

This would be the usual output of `espup install` for a Unix system:
```
[info]: Installing the Espressif Rust ecosystem
[info]: Checking Rust installation
[info]: Installing Xtensa Rust 1.73.0.1 toolchain
[info]: Installing Xtensa LLVM
[info]: Installing RISC-V Rust targets ('riscv32imc-unknown-none-elf' and 'riscv32imac-unknown-none-elf') for 'nightly' toolchain
[info]: Installing GCC (xtensa-esp-elf)
[info]: Installing GCC (riscv32-esp-elf)
[info]: Downloading 'rust.tar.xz'
[info]: Downloading 'xtensa-esp-elf.tar.xz'
[info]: Downloading 'idf_tool_xtensa_elf_clang.tar.xz'
[info]: Downloading 'riscv32-esp-elf.tar.xz'
[info]: Installing 'rust' component for Xtensa Rust toolchain
[info]: Downloading 'rust-src.tar.xz'
[info]: Installing 'rust-src' component for Xtensa Rust toolchain
[info]: Installation successfully completed!
        To get started you may need to restart your current shell.
        To configure your current shell, run:
        '. /home/esp/.rustup/toolchains/esp/env' or '. /home/esp/.rustup/toolchains/esp/env.fish' depending on your shell
```