### PR TITLE
Fix/ghtoken

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,8 +7,12 @@ pub enum Error {
     CreateDirectory(String),
 
     #[diagnostic(code(espup::toolchain::rust::query_github))]
-    #[error("Failed to query GitHub API")]
-    GithubQuery,
+    #[error("Failed to query GitHub API: Rate Limiting")]
+    GithubRateLimit,
+
+    #[diagnostic(code(espup::toolchain::rust::query_github))]
+    #[error("Failed to query GitHub API: Invalid Github token")]
+    GithubTokenInvalid,
 
     #[diagnostic(code(espup::toolchain::rust::install_riscv_target))]
     #[error("Failed to Install RISC-V targets for '{0}' toolchain")]

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -15,7 +15,6 @@ use crate::{
     },
 };
 use async_trait::async_trait;
-use clap::builder::OsStr;
 use flate2::bufread::GzDecoder;
 use log::{debug, info, warn};
 use miette::Result;
@@ -153,7 +152,7 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
                 e,
                 rust::TOOLCHAIN_FALLBACK
             );
-            return String::from(rust::TOOLCHAIN_FALLBACK);
+            String::from(rust::TOOLCHAIN_FALLBACK)
         })
     };
     let toolchain_dir = get_rustup_home().join("toolchains").join(args.name);

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -35,7 +35,7 @@ const DEFAULT_XTENSA_RUST_REPOSITORY: &str =
     "https://github.com/esp-rs/rust-build/releases/download";
 
 /// Xtensa Rust Toolchain fallback version
-static TOOLCHAIN_FALLBACK: &str = "v1.57.0.2";
+pub const TOOLCHAIN_FALLBACK: &str = "1.57.0.2";
 
 /// Xtensa Rust Toolchain API URL
 const XTENSA_RUST_LATEST_API_URL: &str =

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -33,6 +33,10 @@ use tokio::fs::{remove_dir_all, remove_file};
 /// Xtensa Rust Toolchain repository
 const DEFAULT_XTENSA_RUST_REPOSITORY: &str =
     "https://github.com/esp-rs/rust-build/releases/download";
+
+/// Xtensa Rust Toolchain fallback version
+static TOOLCHAIN_FALLBACK: &str = "v1.57.0.2";
+
 /// Xtensa Rust Toolchain API URL
 const XTENSA_RUST_LATEST_API_URL: &str =
     "https://api.github.com/repos/esp-rs/rust-build/releases/latest";


### PR DESCRIPTION
When the environment contains a github token (that is read automatically) which is not valid anymore, the github API request will fail, leaving the CLI with an unclear error about the version.

This PR introduces a new error type for failure when logging into the API and will use a hardcoded fallback version of a known good toolchain.
This version should be bumped regularly (Idea: maybe use dpendabot for that?)
