### PR TITLE
Allow specifying export file via ESPUP_EXPORT_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for specifying the location of the export file via `ESPUP_EXPORT_FILE` (#403)
+
 ### Fixed
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70"
 
 [dependencies]
 async-trait = "0.1.74"
-clap = { version = "4.4.11", features = ["derive"] }
+clap = { version = "4.4.11", features = ["derive", "env"] }
 clap_complete = "4.4.4"
 console = "0.15.7"
 directories = "5.0.1"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Options:
   -f, --export-file <EXPORT_FILE>
           Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
 
+          [env: ESPUP_EXPORT_FILE=]
+
   -e, --extended-llvm
           Extends the LLVM installation.
 
@@ -208,6 +210,8 @@ Options:
 
   -f, --export-file <EXPORT_FILE>
           Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html)
+
+          [env: ESPUP_EXPORT_FILE=]
 
   -e, --extended-llvm
           Extends the LLVM installation.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ pub struct InstallOpts {
     #[arg(short = 'r', long)]
     pub esp_riscv_gcc: bool,
     /// Relative or full path for the export file that will be generated. If no path is provided, the file will be generated under home directory (https://docs.rs/dirs/latest/dirs/fn.home_dir.html).
-    #[arg(short = 'f', long)]
+    #[arg(short = 'f', long, env = "ESPUP_EXPORT_FILE")]
     pub export_file: Option<PathBuf>,
     /// Extends the LLVM installation.
     ///


### PR DESCRIPTION
This adds support for specifying the location of the export file via the environment variable `ESPUP_EXPORT_FILE`. So one does not have to remember to explicitly specify `--export-file FILE` when installling or updating with a custom location of that file.