### PR TITLE
Add support for ESP32-P4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for specifying the location of the export file via `ESPUP_EXPORT_FILE` (#403)
+- Added support for ESP32-P4 (#408)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Options:
           With this option, espup will skip GCC installation (it will be handled by esp-idf-sys), hence you won't be able to build no_std applications.
 
   -t, --targets <TARGETS>
-          Comma or space separated list of targets [esp32,esp32c2,esp32c3,esp32c6,esp32h2,esp32s2,esp32s3,all]
+          Comma or space separated list of targets [esp32,esp32c2,esp32c3,esp32c6,esp32h2,esp32s2,esp32s3,esp32p4,all]
 
           [default: all]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,7 +51,7 @@ pub struct InstallOpts {
     /// With this option, espup will skip GCC installation (it will be handled by esp-idf-sys), hence you won't be able to build no_std applications.
     #[arg(short = 's', long)]
     pub std: bool,
-    /// Comma or space separated list of targets [esp32,esp32c2,esp32c3,esp32c6,esp32h2,esp32s2,esp32s3,all].
+    /// Comma or space separated list of targets [esp32,esp32c2,esp32c3,esp32c6,esp32h2,esp32s2,esp32s3,esp32p4,all].
     #[arg(short = 't', long, default_value = "all", value_parser = parse_targets)]
     pub targets: HashSet<Target>,
     /// Xtensa Rust toolchain version.

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -23,6 +23,8 @@ pub enum Target {
     ESP32S2,
     /// Xtensa LX7 based dual core
     ESP32S3,
+    /// RISC-V based dual core
+    ESP32P4,
 }
 
 impl Target {
@@ -90,6 +92,7 @@ mod tests {
             Target::ESP32H2,
             Target::ESP32S2,
             Target::ESP32S3,
+            Target::ESP32P4,
         ]
         .into_iter()
         .collect();

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -200,7 +200,10 @@ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()>
         to_install.push(Box::new(xtensa_rust.to_owned()));
     }
 
-    to_install.push(Box::new(llvm));
+    // Check if ther is any Xtensa target
+    if targets.iter().any(|t| t.is_xtensa()) {
+        to_install.push(Box::new(llvm.to_owned()));
+    }
 
     if targets.iter().any(|t| t.is_riscv()) {
         let riscv_target = RiscVTarget::new(&args.nightly_version);

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -335,6 +335,7 @@ impl RiscVTarget {
                 nightly_version,
                 "riscv32imc-unknown-none-elf",
                 "riscv32imac-unknown-none-elf",
+                "riscv32imafc-unknown-none-elf",
             ])
             .stdout(Stdio::null())
             .status()?
@@ -350,7 +351,7 @@ impl RiscVTarget {
 impl Installable for RiscVTarget {
     async fn install(&self) -> Result<Vec<String>, Error> {
         info!(
-            "Installing RISC-V Rust targets ('riscv32imc-unknown-none-elf' and 'riscv32imac-unknown-none-elf') for '{}' toolchain",            &self.nightly_version
+            "Installing RISC-V Rust targets ('riscv32imc-unknown-none-elf', 'riscv32imac-unknown-none-elf' and 'riscv32imafc-unknown-none-elf') for '{}' toolchain",            &self.nightly_version
         );
 
         if !Command::new("rustup")
@@ -365,6 +366,7 @@ impl Installable for RiscVTarget {
                 "--target",
                 "riscv32imc-unknown-none-elf",
                 "riscv32imac-unknown-none-elf",
+                "riscv32imafc-unknown-none-elf",
             ])
             .stdout(Stdio::null())
             .stderr(Stdio::null())


### PR DESCRIPTION
Draft until `riscv32imafc-unknown-none-elf` is supported as tier 2 target: https://github.com/rust-lang/rust/pull/118704