### PR TITLE
Update env.rs

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -164,6 +164,13 @@ pub fn print_post_install_msg(export_file: &Path) -> Result<(), Error> {
             "\tA file was created at '{}' showing the injected environment variables",
             export_file.display()
         );
+        println!(
+            "\n\tIf you get still get errors, try manually adding the environment variables with the command"
+        );
+        println!(
+            "\x1b[32m\n\t'{}'\x1b[0m",
+            export_file.display()
+        );
     }
     #[cfg(unix)]
     if cfg!(unix) {

--- a/src/env.rs
+++ b/src/env.rs
@@ -165,11 +165,7 @@ pub fn print_post_install_msg(export_file: &Path) -> Result<(), Error> {
             export_file.display()
         );
         println!(
-            "\n\tIf you get still get errors, try manually adding the environment variables with the command"
-        );
-        println!(
-            "\x1b[32m\n\t'{}'\x1b[0m",
-            export_file.display()
+        println!("\tIf you get still get errors, try manually adding the environment variables by running '{}'", export_file.display()
         );
     }
     #[cfg(unix)]

--- a/src/env.rs
+++ b/src/env.rs
@@ -164,7 +164,6 @@ pub fn print_post_install_msg(export_file: &Path) -> Result<(), Error> {
             "\tA file was created at '{}' showing the injected environment variables",
             export_file.display()
         );
-        println!(
         println!("\tIf you get still get errors, try manually adding the environment variables by running '{}'", export_file.display()
         );
     }


### PR DESCRIPTION
The book says "There is no need to execute the file for Windows users. It is only created to show the modified environment variables.". This appears to be out of date.

On Windows 10, using powershell in VS Code, nothing builds correctly without first running the environment file as a command.

```
cargo generate esp-rs/esp-idf-template cargo
cd projectname
cargo build
```

Fails unless I first do `C:\Users\ryankopf\export-esp.ps1`.