### PR TITLE
Fix extended LLVM mode for LLVM < 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix extended LLVM mode regression for LLVM versions < 17 introduced by #432. (#437)
+
 ## [0.12.1] - 2024-07-15
 
 ### Fixed


### PR DESCRIPTION
The fix for extended LLVM mode with LLVM 17 accidentally broke it for toolchain versions using LLVM 15 and 16.