### PR TITLE
Update to GCC 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
+- Update GCC version to 14.2.0 (#442)
 
 ### Removed
 

--- a/src/toolchain/gcc.rs
+++ b/src/toolchain/gcc.rs
@@ -16,7 +16,7 @@ use std::{env, fs::File};
 use tokio::fs::remove_dir_all;
 
 const DEFAULT_GCC_REPOSITORY: &str = "https://github.com/espressif/crosstool-NG/releases/download";
-const DEFAULT_GCC_RELEASE: &str = "13.2.0_20230928";
+const DEFAULT_GCC_RELEASE: &str = "14.2.0_20240906";
 pub const RISCV_GCC: &str = "riscv32-esp-elf";
 pub const XTENSA_GCC: &str = "xtensa-esp-elf";
 


### PR DESCRIPTION
Use latest GCC release https://github.com/espressif/crosstool-NG/releases/tag/esp-14.2.0_20240906