### PR TITLE
Add support for LLVM 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update GCC version to 14.2.0 (#442)
+- Update LLVM version to esp-18.1.2_20240912 (#452)
 
 ### Removed
 


### PR DESCRIPTION
Testing done inside the devcontainer of espup:
```
cargo r -r -- uninstall
cargo r -r -- install -v 1.81.0.0
cargo r -r -- install -v 1.82.0.0 -l debug
```
Results in the following export file:
```
export PATH="/home/esp/.rustup/toolchains/esp/xtensa-esp-elf/esp-14.2.0_20240906/xtensa-esp-elf/bin:$PATH"
export LIBCLANG_PATH="/home/esp/.rustup/toolchains/esp/xtensa-esp32-elf-clang/esp-18.1.2_20240912/esp-clang/lib"
```
And leaves both llvms installed under `/home/esp/.rustup/toolchains/esp/xtensa-esp32-elf-clang`. Note that 1.81 installs LLVM 17 and 1.82 LLVM 18.

Activating the environment, I was able to build and flash a fresh template for S3.