### PR TITLE
refactor: smoother large file download&proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ version = "0.13.1-dev"
 dependencies = [
  "assert_cmd",
  "async-trait",
+ "bytes",
  "clap",
  "clap_complete",
  "directories",
@@ -575,6 +576,7 @@ dependencies = [
  "thiserror 2.0.3",
  "tokio",
  "tokio-retry",
+ "tokio-stream",
  "update-informer",
  "winapi",
  "winreg 0.52.0",
@@ -663,6 +665,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +695,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1712,10 +1726,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-socks",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "windows-registry",
 ]
@@ -2351,6 +2367,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,6 +2614,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.74.1"
 
 [dependencies]
 async-trait = "0.1.83"
+bytes = "1.8.0"
 clap = { version = "4.5.21", features = ["derive", "env"] }
 clap_complete = "4.5.38"
 directories = "5.0.1"
@@ -24,7 +25,7 @@ guess_host_triple = "0.1.4"
 log = "0.4.22"
 miette = { version = "7.3.0", features = ["fancy"] }
 regex = "1.11.1"
-reqwest = { version = "0.12.9", features = ["blocking", "socks"] }
+reqwest = { version = "0.12.9", features = ["blocking", "socks", "stream"] }
 retry = "2.0.0"
 serde_json = "1.0.133"
 strum = { version = "0.26.3", features = ["derive"] }
@@ -33,6 +34,7 @@ tempfile = "3.14.0"
 thiserror = "2.0.3"
 tokio = { version = "1.41.1", features = ["full"] }
 tokio-retry = "0.3.0"
+tokio-stream = "0.1.17"
 update-informer = "1.1.0"
 xz2 = "0.1.7"
 zip = "2.2.1"

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -110,9 +110,9 @@ pub async fn download_file(
             let chunk = chunk_result?;
             size_downloaded += chunk.len();
             if let Some(len) = len {
-                print!("\rDownloading {}/{} bytes", size_downloaded, len);
+                print!("\rDownloading {file_name} {}/{} bytes", size_downloaded, len);
             } else {
-                print!("\rDownloaded {} bytes", size_downloaded);
+                print!("\rDownloaded {file_name} {} bytes", size_downloaded);
             }
 
             bytes.extend(&chunk);


### PR DESCRIPTION
add a few changes to improve user experience:
- make download files stream which improve experience when downloading larger files(like `rust.zip`)
- read https_proxy/all_proxy from env var(cross platform behavior) from `https_proxy/HTTPS_PROXY/all_proxy/ALL_PROXY` var
- make some blocking function call in async context into `spawn_blocking` so tokio wouldn't panic in debug mode