### PR TITLE
Try fix install failure #480

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Return an error if GET request fails (#471)
+- Fix RISC-V install fail (#480)
 
 ### Changed
 

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -371,9 +371,12 @@ impl Installable for RiscVTarget {
                 "minimal",
                 "--component",
                 "rust-src",
-                "--target", "riscv32imc-unknown-none-elf",
-                "--target", "riscv32imac-unknown-none-elf",
-                "--target", "riscv32imafc-unknown-none-elf",
+                "--target",
+                "riscv32imc-unknown-none-elf",
+                "--target",
+                "riscv32imac-unknown-none-elf",
+                "--target",
+                "riscv32imafc-unknown-none-elf",
             ])
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -371,8 +371,9 @@ impl Installable for RiscVTarget {
                 "minimal",
                 "--component",
                 "rust-src",
-                "--target",
-                "riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf",
+                "--target", "riscv32imc-unknown-none-elf",
+                "--target", "riscv32imac-unknown-none-elf",
+                "--target", "riscv32imafc-unknown-none-elf",
             ])
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/src/toolchain/rust.rs
+++ b/src/toolchain/rust.rs
@@ -372,9 +372,7 @@ impl Installable for RiscVTarget {
                 "--component",
                 "rust-src",
                 "--target",
-                "riscv32imc-unknown-none-elf",
-                "riscv32imac-unknown-none-elf",
-                "riscv32imafc-unknown-none-elf",
+                "riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf",
             ])
             .stdout(Stdio::null())
             .stderr(Stdio::null())


### PR DESCRIPTION
related: #480  #458 #397

Issue:

1. case 1:
`rustup toolchain install nightly --profile minimal --component rust-src --target riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf` *OK*

2. case 2:
`rustup toolchain install nightly --profile minimal --component rust-src --target riscv32imc-unknown-none-elf --target riscv32imac-unknown-none-elf --target riscv32imafc-unknown-none-elf` *OK*

3. case 3:
`rustup toolchain install nightly --profile minimal --component rust-src --target riscv32imc-unknown-none-elf riscv32imac-unknown-none-elf riscv32imafc-unknown-none-elf` *FAIL*

