### PR TITLE
Fix a documentation dead url from the cli

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -178,7 +178,7 @@ pub fn print_post_install_msg(export_file: &Path) -> Result<(), Error> {
             export_file.display()
         );
         println!(
-            "\tThis step must be done every time you open a new terminal.\n\t    See other methods for setting the environment in https://esp-rs.github.io/book/installation/riscv-and-xtensa.html#3-set-up-the-environment-variables",
+            "\tThis step must be done every time you open a new terminal.\n\t    See other methods for setting the environment in https://github.com/esp-rs/espup/?tab=readme-ov-file#environment-variables-setup",
         );
     }
     Ok(())


### PR DESCRIPTION
Quick pull request to fix some 404 urls from the cli.

Previous url https://esp-rs.github.io/book/installation/riscv-and-xtensa.html#3-set-up-the-environment-variables doesn't exists anymore. The book doesn't have that header and redirects to https://github.com/esp-rs/espup/?tab=readme-ov-file#environment-variables-setup (in this repo)
