### PR TITLE
Fix link to The Rust on ESP Book

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 `espup` is a tool for installing and maintaining the required toolchains for developing applications in Rust for Espressif SoC's.
 
-To better understand what `espup` installs, see [the installation chapter of `The Rust on ESP Book`](https://docs.espressif.com/projects/rust/book/)
+To better understand what `espup` installs, see [the installation chapter of `The Rust on ESP Book`](https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 `espup` is a tool for installing and maintaining the required toolchains for developing applications in Rust for Espressif SoC's.
 
-To better understand what `espup` installs, see [the installation chapter of `The Rust on ESP Book`](https://esp-rs.github.io/book/installation/index.html)
+To better understand what `espup` installs, see [the installation chapter of `The Rust on ESP Book`](https://docs.espressif.com/projects/rust/book/)
 
 ## Requirements
 


### PR DESCRIPTION
The current link https://esp-rs.github.io/book/installation/index.html results in a redirect to https://docs.espressif.com/projects/rust/book/installation/index.html which returns 404.
I am not sure, if it should directly fixed in the README or in the redirect.